### PR TITLE
Add check for adding #[non_exhaustive] causing breakage.

### DIFF
--- a/scripts/regenerate_test_rustdocs.sh
+++ b/scripts/regenerate_test_rustdocs.sh
@@ -19,6 +19,7 @@ mv "$RUSTDOC_OUTPUT" "$TARGET_DIR/baseline.json"
 
 # For each feature, re-run rustdoc with it enabled.
 features=(
+    'struct_marked_non_exhaustive'
     'struct_missing'
     'struct_pub_field_missing'
     'enum_missing'

--- a/semver_tests/Cargo.toml
+++ b/semver_tests/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 
 [features]
+struct_marked_non_exhaustive = []
 struct_missing = []
 struct_pub_field_missing = []
 enum_missing = []

--- a/semver_tests/src/test_cases.rs
+++ b/semver_tests/src/test_cases.rs
@@ -21,3 +21,30 @@ pub enum VariantWillBeRemoved {
     #[cfg(not(feature = "enum_variant_missing"))]
     Bar,
 }
+
+/// Breaking change because of:
+///
+/// """
+/// Non-exhaustive types cannot be constructed outside of the defining crate:
+/// - Non-exhaustive variants (struct or enum variant) cannot be constructed with
+///   a StructExpression (including with functional update syntax).
+/// """
+/// From: <https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute>
+#[cfg(not(feature = "struct_marked_non_exhaustive"))]
+pub struct ExternallyConstructibleStruct {
+    pub foo: u64,
+}
+
+/// Breaking change because of:
+///
+/// """
+/// Non-exhaustive types cannot be constructed outside of the defining crate:
+/// - Non-exhaustive variants (struct or enum variant) cannot be constructed with
+///   a StructExpression (including with functional update syntax).
+/// """
+/// From: <https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute>
+#[cfg(feature = "struct_marked_non_exhaustive")]
+#[non_exhaustive]
+pub struct ExternallyConstructibleStruct {
+    pub foo: u64,
+}

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -489,22 +489,26 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                 let previous_crate = self.previous_crate;
 
                 Box::new(data_contexts.map(move |ctx| {
-                    let neighbors: Box<dyn Iterator<Item = Self::DataToken> + 'a> =
-                        match &ctx.current_token {
-                            None => Box::new(std::iter::empty()),
-                            Some(token) => {
-                                let origin = token.origin;
-                                let item = token.as_item().expect("token was not an Item");
-                                let item_id = &item.id;
+                    let neighbors: Box<dyn Iterator<Item = Self::DataToken> + 'a> = match &ctx
+                        .current_token
+                    {
+                        None => Box::new(std::iter::empty()),
+                        Some(token) => {
+                            let origin = token.origin;
+                            let item = token.as_item().expect("token was not an Item");
+                            let item_id = &item.id;
 
-                                let path = match origin {
-                                    Origin::CurrentCrate => &current_crate.paths[item_id].path,
-                                    Origin::PreviousCrate => &previous_crate.expect("no baseline provided").paths[item_id].path,
-                                };
+                            let path = match origin {
+                                Origin::CurrentCrate => &current_crate.paths[item_id].path,
+                                Origin::PreviousCrate => {
+                                    &previous_crate.expect("no baseline provided").paths[item_id]
+                                        .path
+                                }
+                            };
 
-                                Box::new(std::iter::once(origin.make_path_token(path)))
-                            }
-                        };
+                            Box::new(std::iter::once(origin.make_path_token(path)))
+                        }
+                    };
 
                     (ctx, neighbors)
                 }))
@@ -739,5 +743,6 @@ mod tests {
         enum_variant_missing,
         struct_missing,
         struct_pub_field_missing,
+        struct_marked_non_exhaustive,
     );
 }

--- a/src/queries/struct_marked_non_exhaustive.ron
+++ b/src/queries/struct_marked_non_exhaustive.ron
@@ -1,0 +1,63 @@
+SemverQuery(
+    id: "struct_marked_non_exhaustive",
+    human_readable_name: "struct marked #[non_exhaustive]",
+    description: "A publicly-visible struct has been marked #[non_exhaustive], but it was previously constructible using a struct literal outside its crate. The #[non_exhaustive] attribute disables that, so this is a major breaking change for code that depends on it.",
+    required_update: Major,
+    reference_link: Some("https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute"),
+    query: r#"
+    {
+        CrateDiff {
+            baseline {
+                item {
+                    ... on Struct {
+                        visibility_limit @filter(op: "=", value: ["$public"]) @output
+                        name @output @tag
+                        struct_type @filter(op: "!=", value: ["$unit"]) @output @tag
+                        attrs @filter(op: "not_contains", value: ["$non_exhaustive"])
+
+                        # Ensure the struct could previously be constructed outside of its crate
+                        # using a struct literal: it did not have any private fields.
+                        field @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                            visibility_limit @filter(op: "=", value: ["$private"])
+                        }
+
+                        path {
+                            path @output @tag
+                        }
+
+                        span_: span @optional {
+                            filename @output
+                            begin_line @output
+                        }
+                    }
+                }
+            }
+            current @fold @transform(op: "count") @filter(op: ">", value: ["$zero"]) {
+                item {
+                    ... on Struct {
+                        visibility_limit @filter(op: "=", value: ["$public"])
+                        name @filter(op: "=", value: ["%name"])
+                        struct_type @filter(op: "=", value: ["%struct_type"])
+
+                        # The struct is now marked #[non_exhaustive] so it can't be constructed
+                        # using a struct literal outside of its crate. This is the breaking change.
+                        attrs @filter(op: "contains", value: ["$non_exhaustive"])
+
+                        path {
+                            path @filter(op: "=", value: ["%path"])
+                        }
+                    }
+                }
+            }
+        }
+    }"#,
+    arguments: {
+        "public": "public",
+        "private": "private",
+        "unit": "unit",
+        "non_exhaustive": "#[non_exhaustive]",
+        "zero": 0,
+    },
+    error_message: "A public struct has been marked #[non_exhaustive], which will prevent it from being constructed using a struct literal outside of its crate. It previously had no private fields, so a struct literal could be used to construct it outside its crate.",
+    per_result_error_template: Some("struct {{name}}, previously in file {{span_filename}}:{{span_begin_line}}"),
+)

--- a/src/test_data/struct_marked_non_exhaustive.output.ron
+++ b/src/test_data/struct_marked_non_exhaustive.output.ron
@@ -1,0 +1,8 @@
+{
+    "name": String("ExternallyConstructibleStruct"),
+    "struct_type": String("plain"),
+    "path": List([String("semver_tests"), String("test_cases"), String("ExternallyConstructibleStruct")]),
+    "span_filename": String("src/test_cases.rs"),
+    "span_begin_line": Uint64(34),
+    "visibility_limit": String("public"),
+}


### PR DESCRIPTION
Per [this page in the Rust language reference](https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute), it seems that adding `#[non_exhaustive]` to a non-unit struct that has no private fields is a major breaking change.

This is because structs with no private fields can have struct literal be used to construct them outside their own crate, but the addition of `#[non_exhaustive]` will prevent struct literals from being used to construct them outside their own crate. Unit structs are not affected since, based on a quick test on `rustc 1.62.0 (a8314ef7d 2022-06-27)`, `#[non_exhaustive]` is ignored on unit structs and they can still be constructed externally using a struct literal.

Will link this to a PR against the cargo semver reference page when I've had a chance to write a PR for it. 