### PR TITLE
Prevent overly broad rule matches on sub-item deletions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,15 +76,24 @@ Checklist:
 - Choose an appropriate name for your query. We'll refer to it as `<query_name>`.
 - Add the query file: `src/queries/<query_name>.ron`.
 - Add a `<query-name>` feature to `semver_tests/Cargo.toml`.
-- Add code that demonstrates that semver issue: write the "baseline" first, and then
-  use `#[cfg(feature = <query_name>)]` and `#[cfg(not(feature = <query_name>))]` as
+- Add a `<query-name>.rs` file in `semver_tests/src/test_cases`.
+- Add code to that file that demonstrates that semver issue: write the "baseline" first,
+  and then use `#[cfg(feature = <query_name>)]` and `#[cfg(not(feature = <query_name>))]` as
   necessary to alter that baseline into a shape that causes the semver issue
   your query looks for.
+- Add test code for false-positives and/or true-but-unintended-positives your query might report.
+  For example, a true-but-unintended output would be if a query that looks for
+  removal of public fields were to report that a struct was removed. This is unintended
+  since it would overwhelm the user with errors, instead of having a separate query that
+  specifically reports the removal of the struct rather than all its fields separately.
 - Add `<query_name>` to the list of features that need rustdoc data
   in `scripts/regenerate_test_rustdocs.sh`.
-- Add the outputs you expect your query to produce over your test case in a new file: `src/test_data/<query_name>.output.run`.
-- Add `<query_name>` to the list of queries tested by the `query_execution_tests!()` macro near the bottom of `src/adapter.rs`.
+- Add the outputs you expect your query to produce over your test case in
+  a new file: `src/test_data/<query_name>.output.run`.
+- Add `<query_name>` to the list of queries tested by the `query_execution_tests!()`
+  macro near the bottom of `src/adapter.rs`.
 - Re-run `./scripts/regenerate_test_rustdocs.sh` to generate the new rustdoc JSON file.
 - Run `cargo test` and ensure your new test appears in the test list and runs correctly.
 - Whew! You're done. Thanks for your contribution.
-- If you have the energy, please try to simplify this process by removing and automating some of these steps.
+- If you have the energy, please try to simplify this process by removing and
+  automating some of these steps.

--- a/semver_tests/src/test_cases/enum_variant_added.rs
+++ b/semver_tests/src/test_cases/enum_variant_added.rs
@@ -1,0 +1,16 @@
+pub enum EnumWithNewVariant {
+    OldVariant,
+
+    #[cfg(feature = "enum_variant_added")]
+    NewVariant,
+}
+
+/// This enum should not be reported by the `enum_variant_added` rule,
+/// since it is non-exhaustive so adding new variants is not breaking.
+#[non_exhaustive]
+pub enum NonExhaustiveEnumWithNewVariant {
+    OldVariant,
+
+    #[cfg(feature = "enum_variant_added")]
+    NewVariant,
+}

--- a/semver_tests/src/test_cases/enum_variant_missing.rs
+++ b/semver_tests/src/test_cases/enum_variant_missing.rs
@@ -10,4 +10,6 @@ pub enum VariantWillBeRemoved {
 /// it will be removed altogether, so the correct rule to catch it is
 /// the `enum_missing` rule and not the rule for missing variants.
 #[cfg(not(feature = "enum_variant_missing"))]
-pub enum ShouldNotMatch {}
+pub enum ShouldNotMatch {
+    Foo,
+}

--- a/semver_tests/src/test_cases/enum_variant_missing.rs
+++ b/semver_tests/src/test_cases/enum_variant_missing.rs
@@ -1,0 +1,13 @@
+pub enum VariantWillBeRemoved {
+    Foo,
+
+    /// Testing: <https://doc.rust-lang.org/cargo/reference/semver.html#item-remove>
+    #[cfg(not(feature = "enum_variant_missing"))]
+    Bar,
+}
+
+/// This enum should not be reported by the `enum_variant_missing` rule:
+/// it will be removed altogether, so the correct rule to catch it is
+/// the `enum_missing` rule and not the rule for missing variants.
+#[cfg(not(feature = "enum_variant_missing"))]
+pub enum ShouldNotMatch {}

--- a/semver_tests/src/test_cases/item_missing.rs
+++ b/semver_tests/src/test_cases/item_missing.rs
@@ -1,0 +1,7 @@
+/// Testing: <https://doc.rust-lang.org/cargo/reference/semver.html#item-remove>
+#[cfg(not(feature = "struct_missing"))]
+pub struct WillBeRemovedStruct;
+
+/// Testing: <https://doc.rust-lang.org/cargo/reference/semver.html#item-remove>
+#[cfg(not(feature = "enum_missing"))]
+pub enum WillBeRemovedEnum {}

--- a/semver_tests/src/test_cases/mod.rs
+++ b/semver_tests/src/test_cases/mod.rs
@@ -1,42 +1,6 @@
 pub mod non_exhaustive;
 pub mod struct_pub_field_missing;
 pub mod enum_variant_missing;
-
-/// Testing: <https://doc.rust-lang.org/cargo/reference/semver.html#item-remove>
-#[cfg(not(feature = "struct_missing"))]
-pub struct WillBeRemovedStruct;
-
-/// Testing: <https://doc.rust-lang.org/cargo/reference/semver.html#item-remove>
-#[cfg(not(feature = "enum_missing"))]
-pub enum WillBeRemovedEnum {}
-
-#[cfg(not(feature = "unit_struct_changed_kind"))]
-pub struct UnitStructToPlain;
-
-#[cfg(feature = "unit_struct_changed_kind")]
-pub struct UnitStructToPlain {}
-
-#[cfg(not(feature = "unit_struct_changed_kind"))]
-#[non_exhaustive]
-pub struct NonExhaustiveUnitStructToPlain;
-
-#[cfg(feature = "unit_struct_changed_kind")]
-#[non_exhaustive]
-pub struct NonExhaustiveUnitStructToPlain {}
-
-pub enum EnumWithNewVariant {
-    OldVariant,
-
-    #[cfg(feature = "enum_variant_added")]
-    NewVariant,
-}
-
-/// This enum should not be reported by the `enum_variant_added` rule,
-/// since it is non-exhaustive so adding new variants is not breaking.
-#[non_exhaustive]
-pub enum NonExhaustiveEnumWithNewVariant {
-    OldVariant,
-
-    #[cfg(feature = "enum_variant_added")]
-    NewVariant,
-}
+pub mod enum_variant_added;
+pub mod unit_struct_changed_kind;
+pub mod item_missing;

--- a/semver_tests/src/test_cases/mod.rs
+++ b/semver_tests/src/test_cases/mod.rs
@@ -1,28 +1,14 @@
 pub mod non_exhaustive;
+pub mod struct_pub_field_missing;
+pub mod enum_variant_missing;
 
 /// Testing: <https://doc.rust-lang.org/cargo/reference/semver.html#item-remove>
 #[cfg(not(feature = "struct_missing"))]
 pub struct WillBeRemovedStruct;
 
-pub struct FieldWillBeRemoved {
-    pub foo: usize,
-
-    /// Testing: <https://doc.rust-lang.org/cargo/reference/semver.html#item-remove>
-    #[cfg(not(feature = "struct_pub_field_missing"))]
-    pub bar: usize,
-}
-
 /// Testing: <https://doc.rust-lang.org/cargo/reference/semver.html#item-remove>
 #[cfg(not(feature = "enum_missing"))]
 pub enum WillBeRemovedEnum {}
-
-pub enum VariantWillBeRemoved {
-    Foo,
-
-    /// Testing: <https://doc.rust-lang.org/cargo/reference/semver.html#item-remove>
-    #[cfg(not(feature = "enum_variant_missing"))]
-    Bar,
-}
 
 #[cfg(not(feature = "unit_struct_changed_kind"))]
 pub struct UnitStructToPlain;

--- a/semver_tests/src/test_cases/struct_pub_field_missing.rs
+++ b/semver_tests/src/test_cases/struct_pub_field_missing.rs
@@ -1,0 +1,13 @@
+pub struct FieldWillBeRemoved {
+    pub foo: usize,
+
+    /// Testing: <https://doc.rust-lang.org/cargo/reference/semver.html#item-remove>
+    #[cfg(not(feature = "struct_pub_field_missing"))]
+    pub bar: usize,
+}
+
+/// This struct should not be reported by the `struct_pub_field_missing` rule:
+/// it will be removed altogether, so the correct rule to catch it is
+/// the `struct_missing` rule and not the rule for missing fields.
+#[cfg(not(feature = "struct_pub_field_missing"))]
+pub struct StructRemoved {}

--- a/semver_tests/src/test_cases/struct_pub_field_missing.rs
+++ b/semver_tests/src/test_cases/struct_pub_field_missing.rs
@@ -10,4 +10,6 @@ pub struct FieldWillBeRemoved {
 /// it will be removed altogether, so the correct rule to catch it is
 /// the `struct_missing` rule and not the rule for missing fields.
 #[cfg(not(feature = "struct_pub_field_missing"))]
-pub struct StructRemoved {}
+pub struct StructRemoved {
+    pub foo: usize,
+}

--- a/semver_tests/src/test_cases/unit_struct_changed_kind.rs
+++ b/semver_tests/src/test_cases/unit_struct_changed_kind.rs
@@ -1,0 +1,13 @@
+#[cfg(not(feature = "unit_struct_changed_kind"))]
+pub struct UnitStructToPlain;
+
+#[cfg(feature = "unit_struct_changed_kind")]
+pub struct UnitStructToPlain {}
+
+#[cfg(not(feature = "unit_struct_changed_kind"))]
+#[non_exhaustive]
+pub struct NonExhaustiveUnitStructToPlain;
+
+#[cfg(feature = "unit_struct_changed_kind")]
+#[non_exhaustive]
+pub struct NonExhaustiveUnitStructToPlain {}

--- a/src/queries/enum_variant_missing.ron
+++ b/src/queries/enum_variant_missing.ron
@@ -28,7 +28,7 @@ SemverQuery(
                     }
                 }
             }
-            current @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+            current {
                 item {
                     ... on Enum {
                         visibility_limit @filter(op: "=", value: ["$public"])
@@ -38,7 +38,7 @@ SemverQuery(
                             path @filter(op: "=", value: ["%path"])
                         }
 
-                        variant {
+                        variant @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
                             name @filter(op: "=", value: ["%variant_name"])
                         }
                     }

--- a/src/queries/struct_pub_field_missing.ron
+++ b/src/queries/struct_pub_field_missing.ron
@@ -30,7 +30,7 @@ SemverQuery(
                     }
                 }
             }
-            current @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+            current {
                 item {
                     ... on Struct {
                         visibility_limit @filter(op: "=", value: ["$public"])
@@ -41,7 +41,7 @@ SemverQuery(
                             path @filter(op: "=", value: ["%path"])
                         }
 
-                        field {
+                        field  @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
                             name @filter(op: "=", value: ["%field_name"])
                             visibility_limit @filter(op: "=", value: ["$public"])
                         }

--- a/src/queries/struct_pub_field_missing.ron
+++ b/src/queries/struct_pub_field_missing.ron
@@ -41,7 +41,7 @@ SemverQuery(
                             path @filter(op: "=", value: ["%path"])
                         }
 
-                        field  @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                        field @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
                             name @filter(op: "=", value: ["%field_name"])
                             visibility_limit @filter(op: "=", value: ["$public"])
                         }

--- a/src/test_data/enum_missing.output.ron
+++ b/src/test_data/enum_missing.output.ron
@@ -1,9 +1,14 @@
 [
     {
         "name": String("WillBeRemovedEnum"),
-        "path": List([String("semver_tests"), String("test_cases"), String("WillBeRemovedEnum")]),
+        "path": List([
+            String("semver_tests"),
+            String("test_cases"),
+            String("item_missing"),
+            String("WillBeRemovedEnum"),
+        ]),
         "visibility_limit": String("public"),
-        "span_filename": String("src/test_cases/mod.rs"),
-        "span_begin_line": Uint64(11),
+        "span_filename": String("src/test_cases/item_missing.rs"),
+        "span_begin_line": Uint64(7),
     }
 ]

--- a/src/test_data/enum_missing.output.ron
+++ b/src/test_data/enum_missing.output.ron
@@ -4,6 +4,6 @@
         "path": List([String("semver_tests"), String("test_cases"), String("WillBeRemovedEnum")]),
         "visibility_limit": String("public"),
         "span_filename": String("src/test_cases/mod.rs"),
-        "span_begin_line": Uint64(17),
+        "span_begin_line": Uint64(11),
     }
 ]

--- a/src/test_data/enum_variant_added.output.ron
+++ b/src/test_data/enum_variant_added.output.ron
@@ -2,9 +2,14 @@
     {
         "enum_name": String("EnumWithNewVariant"),
         "variant_name": String("NewVariant"),
-        "path": List([String("semver_tests"), String("test_cases"), String("EnumWithNewVariant")]),
+        "path": List([
+            String("semver_tests"),
+            String("test_cases"),
+            String("enum_variant_added"),
+            String("EnumWithNewVariant"),
+        ]),
         "visibility_limit": String("public"),
-        "span_filename": String("src/test_cases/mod.rs"),
-        "span_begin_line": Uint64(31),
+        "span_filename": String("src/test_cases/enum_variant_added.rs"),
+        "span_begin_line": Uint64(5),
     }
 ]

--- a/src/test_data/enum_variant_added.output.ron
+++ b/src/test_data/enum_variant_added.output.ron
@@ -5,6 +5,6 @@
         "path": List([String("semver_tests"), String("test_cases"), String("EnumWithNewVariant")]),
         "visibility_limit": String("public"),
         "span_filename": String("src/test_cases/mod.rs"),
-        "span_begin_line": Uint64(45),
+        "span_begin_line": Uint64(31),
     }
 ]

--- a/src/test_data/enum_variant_missing.output.ron
+++ b/src/test_data/enum_variant_missing.output.ron
@@ -2,9 +2,9 @@
     {
         "enum_name": String("VariantWillBeRemoved"),
         "variant_name": String("Bar"),
-        "path": List([String("semver_tests"), String("test_cases"), String("VariantWillBeRemoved")]),
+        "path": List([String("semver_tests"), String("test_cases"), String("enum_variant_missing"), String("VariantWillBeRemoved")]),
         "visibility_limit": String("public"),
-        "span_filename": String("src/test_cases/mod.rs"),
-        "span_begin_line": Uint64(24),
+        "span_filename": String("src/test_cases/enum_variant_missing.rs"),
+        "span_begin_line": Uint64(6),
     }
 ]

--- a/src/test_data/enum_variant_missing.output.ron
+++ b/src/test_data/enum_variant_missing.output.ron
@@ -2,7 +2,12 @@
     {
         "enum_name": String("VariantWillBeRemoved"),
         "variant_name": String("Bar"),
-        "path": List([String("semver_tests"), String("test_cases"), String("enum_variant_missing"), String("VariantWillBeRemoved")]),
+        "path": List([
+            String("semver_tests"),
+            String("test_cases"),
+            String("enum_variant_missing"),
+            String("VariantWillBeRemoved"),
+        ]),
         "visibility_limit": String("public"),
         "span_filename": String("src/test_cases/enum_variant_missing.rs"),
         "span_begin_line": Uint64(6),

--- a/src/test_data/struct_missing.output.ron
+++ b/src/test_data/struct_missing.output.ron
@@ -2,9 +2,14 @@
     {
         "name": String("WillBeRemovedStruct"),
         "struct_type": String("unit"),
-        "path": List([String("semver_tests"), String("test_cases"), String("WillBeRemovedStruct")]),
+        "path": List([
+            String("semver_tests"),
+            String("test_cases"),
+            String("item_missing"),
+            String("WillBeRemovedStruct"),
+        ]),
         "visibility_limit": String("public"),
-        "span_filename": String("src/test_cases/mod.rs"),
-        "span_begin_line": Uint64(7),
+        "span_filename": String("src/test_cases/item_missing.rs"),
+        "span_begin_line": Uint64(3),
     }
 ]

--- a/src/test_data/struct_missing.output.ron
+++ b/src/test_data/struct_missing.output.ron
@@ -5,6 +5,6 @@
         "path": List([String("semver_tests"), String("test_cases"), String("WillBeRemovedStruct")]),
         "visibility_limit": String("public"),
         "span_filename": String("src/test_cases/mod.rs"),
-        "span_begin_line": Uint64(5),
+        "span_begin_line": Uint64(7),
     }
 ]

--- a/src/test_data/struct_pub_field_missing.output.ron
+++ b/src/test_data/struct_pub_field_missing.output.ron
@@ -2,9 +2,14 @@
     {
         "struct_name": String("FieldWillBeRemoved"),
         "struct_type": String("plain"),
-        "path": List([String("semver_tests"), String("test_cases"), String("FieldWillBeRemoved")]),
+        "path": List([
+            String("semver_tests"),
+            String("test_cases"),
+            String("struct_pub_field_missing"),
+            String("FieldWillBeRemoved"),
+        ]),
         "field_name": String("bar"),
-        "span_filename": String("src/test_cases/mod.rs"),
-        "span_begin_line": Uint64(12),
+        "span_filename": String("src/test_cases/struct_pub_field_missing.rs"),
+        "span_begin_line": Uint64(6),
     }
 ]

--- a/src/test_data/unit_struct_changed_kind.output.ron
+++ b/src/test_data/unit_struct_changed_kind.output.ron
@@ -4,6 +4,6 @@
         "path": List([String("semver_tests"), String("test_cases"), String("UnitStructToPlain")]),
         "visibility_limit": String("public"),
         "span_filename": String("src/test_cases/mod.rs"),
-        "span_begin_line": Uint64(31),
+        "span_begin_line": Uint64(17),
     }
 ]

--- a/src/test_data/unit_struct_changed_kind.output.ron
+++ b/src/test_data/unit_struct_changed_kind.output.ron
@@ -1,9 +1,14 @@
 [
     {
         "name": String("UnitStructToPlain"),
-        "path": List([String("semver_tests"), String("test_cases"), String("UnitStructToPlain")]),
+        "path": List([
+            String("semver_tests"),
+            String("test_cases"),
+            String("unit_struct_changed_kind"),
+            String("UnitStructToPlain"),
+        ]),
         "visibility_limit": String("public"),
-        "span_filename": String("src/test_cases/mod.rs"),
-        "span_begin_line": Uint64(17),
+        "span_filename": String("src/test_cases/unit_struct_changed_kind.rs"),
+        "span_begin_line": Uint64(5),
     }
 ]


### PR DESCRIPTION
- Prevent overly broad rule matches on sub-item deletions.
- Break out all test cases out of mod.rs.
- Clarify testing instructions in README.md.
