### PR TITLE
Fix for moving method to trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "869119e97797867fd90f5e22af7d0bd274bd4635ebb9eb68c04f3f513ae6c412"
 
 [[package]]
 name = "cargo-semver-checks"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-semver-checks"
-version = "0.4.4"
+version = "0.5.0"
 edition = "2021"
 authors = ["Predrag Gruevski <obi1kenobi82@gmail.com>"]
 license = "Apache-2.0"

--- a/semver_tests/src/test_cases/item_missing.rs
+++ b/semver_tests/src/test_cases/item_missing.rs
@@ -21,4 +21,24 @@ impl Foo {
 
     #[cfg(not(feature = "inherent_method_missing"))]
     pub fn will_be_removed_method(&self) {}
+
+    #[cfg(not(feature = "inherent_method_missing"))]
+    pub fn moved_trait_provided_method(&self) {}
+
+    #[cfg(not(feature = "inherent_method_missing"))]
+    pub fn moved_method(&self) {}
+}
+
+// Moving an inherent method to an implemented trait should not be a breaking change,
+// both when the method is defined inside the trait and when it's implemented externally.
+#[cfg(feature = "inherent_method_missing")]
+pub trait Bar {
+    fn moved_trait_provided_method(&self) {}
+
+    fn moved_method(&self);
+}
+
+#[cfg(feature = "inherent_method_missing")]
+impl Bar for Foo {
+    fn moved_method(&self) {}
 }

--- a/src/queries/inherent_method_missing.ron
+++ b/src/queries/inherent_method_missing.ron
@@ -41,9 +41,12 @@ SemverQuery(
                             path @filter(op: "=", value: ["%path"])
                         }
 
-                        inherent_impl @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
+                        # We use "impl" instead of "inherent_impl" here because moving
+                        # an inherently-implemented method to a trait is not necessarily
+                        # a breaking change, so we don't want to report it.
+                        impl @fold @transform(op: "count") @filter(op: "=", value: ["$zero"]) {
                             method {
-                                visibility_limit @filter(op: "=", value: ["$public"])
+                                visibility_limit @filter(op: "one_of", value: ["$public_or_default"])
                                 name @filter(op: "=", value: ["%method_name"])
                             }
                         }
@@ -54,6 +57,7 @@ SemverQuery(
     }"#,
     arguments: {
         "public": "public",
+        "public_or_default": ["public", "default"],
         "zero": 0,
     },
     error_message: "A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.",


### PR DESCRIPTION
Moving a method from an inherent impl into a pub trait that is implemented by the same type is not necessarily breaking, and should not be reported as `inherent method missing`.