### PR TITLE
Adapt to new rustdoc JSON file format.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "rustdoc-types"
-version = "0.11.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa792ee5551052d6e577cedadec6f7eae744b26db967e8e9fb4c1b604a608c7f"
+checksum = "eb8ae6df9a4006b7968781abb9a2ea2983b5f3cad2ca9294d195781618194c28"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["command-line-utilities", "development-tools::cargo-plugins"]
 
 [dependencies]
 trustfall_core = "0.0.4"
-rustdoc-types = "0.11.0"
+rustdoc-types = "0.14.0"
 clap = { version = "3.2.8", features = ["cargo"] }
 serde_json = "1.0.82"
 anyhow = "1.0.58"

--- a/src/rustdoc_schema.graphql
+++ b/src/rustdoc_schema.graphql
@@ -509,6 +509,11 @@ A type represented in the "raw" rustdoc JSON representation.
 
 Copiously detailed, but not the easiest to use due to its complexity.
 
+This interface is a temporary, perma-unstable type intended to be used
+only until the rustdoc JSON format is stabilized and until subsequently
+we are able to design a better, more permanent representation for
+Rust types in this schema.
+
 https://docs.rs/rustdoc-types/latest/rustdoc_types/enum.Type.html
 """
 interface RawType {
@@ -534,8 +539,7 @@ The trait that is being implemented in an impl block.
 
 In `impl Foo<u64> for Bar`, this is the `Foo<u64>` part.
 """
-type ImplementedTrait implements RawType & ResolvedPathType {
-  # properties from RawType
+type ImplementedTrait {
   name: String!
 
   # own edges


### PR DESCRIPTION
These two are the notable changes that affected `cargo-semver-checks`:
https://docs.rs/rustdoc-types/latest/rustdoc_types/enum.Type.html#variant.ResolvedPath
https://docs.rs/rustdoc-types/latest/rustdoc_types/struct.Impl.html#structfield.trait_

The former link's enum used to use struct variants, and the latter link's field used to be `Option<Type>` instead of `Option<Path>`.

Thanks to [Trustfall](https://github.com/obi1kenobi/trustfall), these changes are completely invisible to the query layer; none of the semver queries needed to be changed to accommodate the new format. The schema changes are essentially cosmetic, and the only meaningful changes are located in the adapter implementation.