### PR TITLE
refactor(cli): Reduce number of exit paths

### DIFF
--- a/src/check_release.rs
+++ b/src/check_release.rs
@@ -107,7 +107,7 @@ pub(super) fn run_check_release(
     mut config: GlobalConfig,
     current_crate: Crate,
     baseline_crate: Crate,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<bool> {
     let current_version = current_crate.crate_version.as_deref();
     let baseline_version = baseline_crate.crate_version.as_deref();
 
@@ -390,7 +390,7 @@ pub(super) fn run_check_release(
         })
         .expect("print failed");
 
-        std::process::exit(1);
+        Ok(false)
     } else {
         colored_ln(&mut config.output_writer, |w| {
             colored!(
@@ -407,7 +407,6 @@ pub(super) fn run_check_release(
             )
         })
         .expect("print failed");
+        Ok(true)
     }
-
-    Ok(())
 }

--- a/src/check_release.rs
+++ b/src/check_release.rs
@@ -391,23 +391,23 @@ pub(super) fn run_check_release(
         .expect("print failed");
 
         std::process::exit(1);
+    } else {
+        colored_ln(&mut config.output_writer, |w| {
+            colored!(
+                w,
+                "{}{}{:>12}{} [{:>8.3}s] {} checks run: {} passed, {} skipped",
+                fg!(Some(Color::Green)),
+                bold!(true),
+                "Summary",
+                reset!(),
+                total_duration.as_secs_f32(),
+                queries_to_run.len(),
+                queries_to_run.len(),
+                skipped_queries,
+            )
+        })
+        .expect("print failed");
     }
-
-    colored_ln(&mut config.output_writer, |w| {
-        colored!(
-            w,
-            "{}{}{:>12}{} [{:>8.3}s] {} checks run: {} passed, {} skipped",
-            fg!(Some(Color::Green)),
-            bold!(true),
-            "Summary",
-            reset!(),
-            total_duration.as_secs_f32(),
-            queries_to_run.len(),
-            queries_to_run.len(),
-            skipped_queries,
-        )
-    })
-    .expect("print failed");
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,11 @@ fn main() -> anyhow::Result<()> {
             let current_crate = load_rustdoc_from_file(&args.current_rustdoc_path)?;
             let baseline_crate = load_rustdoc_from_file(&args.baseline_rustdoc_path)?;
 
-            return run_check_release(config, current_crate, baseline_crate);
+            if run_check_release(config, current_crate, baseline_crate)? {
+                std::process::exit(0);
+            } else {
+                std::process::exit(1);
+            }
         }
     }
 }


### PR DESCRIPTION
In working on other changes, I found `run_check_release` exiting in some cases hard to account for.  I've generally found it best to centralize all exits.

If we want to extend this further, a pattern I've found useful is to use the [proc_exit](https://docs.rs/proc-exit/) crate.