### PR TITLE
feat(cli): Generate rustdoc automatically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,7 @@ dependencies = [
  "clap",
  "clap-cargo",
  "handlebars",
+ "ignore",
  "ron 0.7.1",
  "rustdoc-types",
  "semver",
@@ -255,6 +256,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +353,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
+dependencies = [
+ "crossbeam-utils",
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -715,6 +744,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,18 @@ name = "camino"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "869119e97797867fd90f5e22af7d0bd274bd4635ebb9eb68c04f3f513ae6c412"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cargo-semver-checks"
@@ -134,7 +146,9 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "atty",
+ "cargo_metadata",
  "clap",
+ "clap-cargo",
  "handlebars",
  "ron 0.7.1",
  "rustdoc-types",
@@ -143,7 +157,21 @@ dependencies = [
  "serde_json",
  "termcolor",
  "termcolor_output",
+ "toml_edit",
  "trustfall_core",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3abb7553d5b9b8421c6de7cb02606ff15e0c6eea7d8eadd75ef013fd636bec36"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -184,6 +212,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-cargo"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841b17c26cdae63b80cd9014f4fb779b761c388908bdf58e15223a08d65e9b08"
+dependencies = [
+ "cargo_metadata",
+ "clap",
+ "doc-comment",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,6 +245,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +262,12 @@ checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
@@ -538,6 +593,9 @@ name = "semver"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
@@ -668,6 +726,17 @@ dependencies = [
  "libc",
  "wasi",
  "winapi",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
+dependencies = [
+ "combine",
+ "indexmap",
+ "itertools",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ termcolor_output = "1.0.1"
 toml_edit = "0.14.4"
 cargo_metadata = "0.15.0"
 clap-cargo = { version = "0.9.1", features = ["cargo_metadata"] }
+ignore = "0.4.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ handlebars = "4.3.1"
 atty = "0.2.14"
 termcolor = "1.1.3"
 termcolor_output = "1.0.1"
+toml_edit = "0.14.4"
+cargo_metadata = "0.15.0"
+clap-cargo = { version = "0.9.1", features = ["cargo_metadata"] }

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -1,0 +1,19 @@
+pub trait BaselineLoader {
+    fn load_rustdoc(&self, name: &str) -> anyhow::Result<std::path::PathBuf>;
+}
+
+pub struct RustdocBaseline {
+    path: std::path::PathBuf,
+}
+
+impl RustdocBaseline {
+    pub fn new(path: std::path::PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl BaselineLoader for RustdocBaseline {
+    fn load_rustdoc(&self, _name: &str) -> anyhow::Result<std::path::PathBuf> {
+        Ok(self.path.clone())
+    }
+}

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -1,5 +1,9 @@
+use anyhow::Context as _;
+
+use crate::dump::RustDoc;
+
 pub trait BaselineLoader {
-    fn load_rustdoc(&self, name: &str) -> anyhow::Result<std::path::PathBuf>;
+    fn load_rustdoc(&self, rustdoc: &RustDoc, name: &str) -> anyhow::Result<std::path::PathBuf>;
 }
 
 pub struct RustdocBaseline {
@@ -13,7 +17,38 @@ impl RustdocBaseline {
 }
 
 impl BaselineLoader for RustdocBaseline {
-    fn load_rustdoc(&self, _name: &str) -> anyhow::Result<std::path::PathBuf> {
+    fn load_rustdoc(&self, _rustdoc: &RustDoc, _name: &str) -> anyhow::Result<std::path::PathBuf> {
         Ok(self.path.clone())
+    }
+}
+
+pub struct PathBaseline {
+    root: std::path::PathBuf,
+    lookup: std::collections::HashMap<String, std::path::PathBuf>,
+}
+
+impl PathBaseline {
+    pub fn new(root: std::path::PathBuf) -> anyhow::Result<Self> {
+        let mut lookup = std::collections::HashMap::new();
+        for result in ignore::Walk::new(&root) {
+            let entry = result?;
+            if entry.file_name() == "Cargo.toml" {
+                if let Ok(name) = crate::manifest::get_package_name(entry.path()) {
+                    lookup.insert(name, entry.into_path());
+                }
+            }
+        }
+        Ok(Self { root, lookup })
+    }
+}
+
+impl BaselineLoader for PathBaseline {
+    fn load_rustdoc(&self, rustdoc: &RustDoc, name: &str) -> anyhow::Result<std::path::PathBuf> {
+        let manifest_path = self
+            .lookup
+            .get(name)
+            .with_context(|| format!("package `{}` not found in {}", name, self.root.display()))?;
+        let rustdoc_path = rustdoc.dump(manifest_path.as_path())?;
+        Ok(rustdoc_path)
     }
 }

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -1,9 +1,13 @@
 use anyhow::Context as _;
 
-use crate::dump::RustDoc;
+use crate::dump::RustDocCommand;
 
 pub trait BaselineLoader {
-    fn load_rustdoc(&self, rustdoc: &RustDoc, name: &str) -> anyhow::Result<std::path::PathBuf>;
+    fn load_rustdoc(
+        &self,
+        rustdoc: &RustDocCommand,
+        name: &str,
+    ) -> anyhow::Result<std::path::PathBuf>;
 }
 
 pub struct RustdocBaseline {
@@ -17,7 +21,11 @@ impl RustdocBaseline {
 }
 
 impl BaselineLoader for RustdocBaseline {
-    fn load_rustdoc(&self, _rustdoc: &RustDoc, _name: &str) -> anyhow::Result<std::path::PathBuf> {
+    fn load_rustdoc(
+        &self,
+        _rustdoc: &RustDocCommand,
+        _name: &str,
+    ) -> anyhow::Result<std::path::PathBuf> {
         Ok(self.path.clone())
     }
 }
@@ -43,7 +51,11 @@ impl PathBaseline {
 }
 
 impl BaselineLoader for PathBaseline {
-    fn load_rustdoc(&self, rustdoc: &RustDoc, name: &str) -> anyhow::Result<std::path::PathBuf> {
+    fn load_rustdoc(
+        &self,
+        rustdoc: &RustDocCommand,
+        name: &str,
+    ) -> anyhow::Result<std::path::PathBuf> {
         let manifest_path = self
             .lookup
             .get(name)

--- a/src/check_release.rs
+++ b/src/check_release.rs
@@ -104,7 +104,7 @@ fn make_result_iter<'a>(
 }
 
 pub(super) fn run_check_release(
-    mut config: GlobalConfig,
+    config: &mut GlobalConfig,
     current_crate: Crate,
     baseline_crate: Crate,
 ) -> anyhow::Result<bool> {

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -87,7 +87,7 @@ impl RustDocCommand {
             }
         }
 
-        let json_path = target_dir.join(format!("doc/{}.json", crate_name));
+        let json_path = target_dir.join(format!("doc/{}.json", crate_name.replace('-', "_")));
         if !json_path.exists() {
             anyhow::bail!(
                 "Could not find expected rustdoc output: {}",

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -90,7 +90,8 @@ impl RustDocCommand {
         let json_path = target_dir.join(format!("doc/{}.json", crate_name.replace('-', "_")));
         if !json_path.exists() {
             anyhow::bail!(
-                "Could not find expected rustdoc output: {}",
+                "Could not find expected rustdoc output for `{}`: {}",
+                crate_name,
                 json_path.display()
             );
         }

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -1,0 +1,105 @@
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RustDoc {
+    deps: bool,
+    silence: bool,
+}
+
+impl RustDoc {
+    pub fn new() -> Self {
+        Self {
+            deps: false,
+            silence: false,
+        }
+    }
+
+    /// Include dependencies
+    ///
+    /// Reasons to have this disabled:
+    /// - Faster API extraction
+    /// - Less likely to hit bugs in rustdoc, like
+    ///   - rust-lang/rust#89097
+    ///   - rust-lang/rust#83718
+    ///
+    /// Reasons to have this enabled:
+    /// - Check for accidental inclusion of dependencies in your API
+    /// - Detect breaking changes from dependencies in your API
+    pub fn deps(mut self, yes: bool) -> Self {
+        self.deps = yes;
+        self
+    }
+
+    /// Don't write progress to stderr
+    pub fn silence(mut self, yes: bool) -> Self {
+        self.silence = yes;
+        self
+    }
+
+    pub fn dump(&self, manifest_path: &std::path::Path) -> anyhow::Result<std::path::PathBuf> {
+        let crate_name = crate::manifest::get_package_name(manifest_path)?;
+
+        let metadata = cargo_metadata::MetadataCommand::new()
+            .manifest_path(manifest_path)
+            .no_deps()
+            .exec()?;
+        let manifest_target_directory = metadata
+            .target_directory
+            .as_path()
+            .as_std_path()
+            // HACK: Avoid potential errors when mixing toolchains
+            .join("semver-check/target");
+        let target_dir = manifest_target_directory.as_path();
+
+        let stderr = if self.silence {
+            std::process::Stdio::piped()
+        } else {
+            // Print cargo doc progress
+            std::process::Stdio::inherit()
+        };
+
+        let mut cmd = std::process::Command::new("cargo");
+        cmd.env(
+            "RUSTDOCFLAGS",
+            "-Z unstable-options --document-hidden-items --output-format=json",
+        )
+        .stdout(std::process::Stdio::null()) // Don't pollute output
+        .stderr(stderr)
+        .args(["+nightly", "doc", "--all-features"])
+        .arg("--manifest-path")
+        .arg(manifest_path)
+        .arg("--target-dir")
+        .arg(target_dir);
+        if !self.deps {
+            cmd.arg("--no-deps");
+        }
+        let output = cmd.output()?;
+        if !output.status.success() {
+            if self.silence {
+                anyhow::bail!(
+                    "Failed when running cargo-doc on {}: {}",
+                    manifest_path.display(),
+                    String::from_utf8_lossy(&output.stderr)
+                )
+            } else {
+                anyhow::bail!(
+                    "Failed when running cargo-doc on {}. See stderr.",
+                    manifest_path.display(),
+                )
+            }
+        }
+
+        let json_path = target_dir.join(format!("doc/{}.json", crate_name));
+        if !json_path.exists() {
+            anyhow::bail!(
+                "Could not find expected rustdoc output: {}",
+                json_path.display()
+            );
+        }
+        Ok(json_path)
+    }
+}
+
+impl Default for RustDoc {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -1,10 +1,10 @@
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct RustDoc {
+pub struct RustDocCommand {
     deps: bool,
     silence: bool,
 }
 
-impl RustDoc {
+impl RustDocCommand {
     pub fn new() -> Self {
         Self {
             deps: false,
@@ -98,7 +98,7 @@ impl RustDoc {
     }
 }
 
-impl Default for RustDoc {
+impl Default for RustDocCommand {
     fn default() -> Self {
         Self::new()
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,12 +68,12 @@ fn main() -> anyhow::Result<()> {
                 } else {
                     unreachable!("a member of the `baseline` group must be present");
                 };
-            let rustdoc = dump::RustDocCommand::new().deps(false).silence(false);
+            let rustdoc_cmd = dump::RustDocCommand::new().deps(false).silence(false);
 
             let rustdoc_paths =
                 if let Some(current_rustdoc_path) = args.current_rustdoc_path.as_deref() {
                     vec![(
-                        loader.load_rustdoc(&rustdoc, "<unknown>")?,
+                        loader.load_rustdoc(&rustdoc_cmd, "<unknown>")?,
                         current_rustdoc_path.to_owned(),
                     )]
                 } else {
@@ -92,9 +92,9 @@ fn main() -> anyhow::Result<()> {
                     let mut rustdoc_paths = Vec::with_capacity(selected.len());
                     for selected in selected {
                         let manifest_path = selected.manifest_path.as_std_path();
-                        let rustdoc_path = rustdoc.dump(manifest_path)?;
+                        let rustdoc_path = rustdoc_cmd.dump(manifest_path)?;
                         let crate_name = manifest::get_package_name(manifest_path)?;
-                        let baseline_path = loader.load_rustdoc(&rustdoc, &crate_name)?;
+                        let baseline_path = loader.load_rustdoc(&rustdoc_cmd, &crate_name)?;
                         rustdoc_paths.push((baseline_path, rustdoc_path));
                     }
                     rustdoc_paths

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ fn main() -> anyhow::Result<()> {
                 } else {
                     unreachable!("a member of the `baseline` group must be present");
                 };
-            let rustdoc = dump::RustDoc::new().deps(false).silence(false);
+            let rustdoc = dump::RustDocCommand::new().deps(false).silence(false);
 
             let rustdoc_paths =
                 if let Some(current_rustdoc_path) = args.current_rustdoc_path.as_deref() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,14 +53,14 @@ impl GlobalConfig {
 fn main() -> anyhow::Result<()> {
     let Cargo::SemverChecks(args) = Cargo::parse();
 
-    let config = GlobalConfig::new();
+    let mut config = GlobalConfig::new();
 
     match args {
         SemverChecks::CheckRelease(args) => {
             let current_crate = load_rustdoc_from_file(&args.current_rustdoc_path)?;
             let baseline_crate = load_rustdoc_from_file(&args.baseline_rustdoc_path)?;
 
-            if run_check_release(config, current_crate, baseline_crate)? {
+            if run_check_release(&mut config, current_crate, baseline_crate)? {
                 std::process::exit(0);
             } else {
                 std::process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,10 +57,20 @@ fn main() -> anyhow::Result<()> {
 
     match args {
         SemverChecks::CheckRelease(args) => {
-            let current_crate = load_rustdoc_from_file(&args.current_rustdoc_path)?;
-            let baseline_crate = load_rustdoc_from_file(&args.baseline_rustdoc_path)?;
+            let rustdoc_paths = vec![(
+                args.baseline_rustdoc_path.clone(),
+                args.current_rustdoc_path.clone(),
+            )];
+            let mut success = true;
+            for (baseline_path, current_path) in rustdoc_paths {
+                let baseline_crate = load_rustdoc_from_file(&baseline_path)?;
+                let current_crate = load_rustdoc_from_file(&current_path)?;
 
-            if run_check_release(&mut config, current_crate, baseline_crate)? {
+                if !run_check_release(&mut config, current_crate, baseline_crate)? {
+                    success = false;
+                }
+            }
+            if success {
                 std::process::exit(0);
             } else {
                 std::process::exit(1);

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,0 +1,15 @@
+pub fn get_package_name(manifest_path: &std::path::Path) -> anyhow::Result<String> {
+    let manifest = std::fs::read_to_string(manifest_path).map_err(|e| {
+        anyhow::format_err!("Failed when reading {}: {}", manifest_path.display(), e)
+    })?;
+    let manifest: toml_edit::Document = manifest
+        .parse()
+        .map_err(|e| anyhow::format_err!("Failed to parse {}: {}", manifest_path.display(), e))?;
+    let crate_name = manifest["package"]["name"].as_str().ok_or_else(|| {
+        anyhow::format_err!(
+            "Failed to parse {}: invalid package.name",
+            manifest_path.display()
+        )
+    })?;
+    Ok(crate_name.to_owned())
+}


### PR DESCRIPTION
The original command-line will work as usual but now
- If you don't specify `--current`, it will infer the packages like any other cargo command
- Instead of `--baseline`, you can specify `--baseline-root` and it will search it for relevant manifests for what is in current

clap is enforcing the relationships to make this all work.

I've played with integration tests for this but we'll have to decide how well we want to handle that going forward.  I was originally going to do integration tests against all of cargo-semverver's test cases but it was pretty slow :).  I did hand test by having two clap directories set to different commits.

`--baseline-git` will build on this, we'll just clone first.  `--baseline-version` will require a bit more work.

This is best review per-commit to see how it all builds up

Fixes #52