### PR TITLE
fix(cli): Make output behave more like cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,8 +149,10 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "clap-cargo",
+ "clap-verbosity-flag",
  "handlebars",
  "ignore",
+ "log",
  "ron 0.7.1",
  "rustdoc-types",
  "semver",
@@ -221,6 +223,16 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "doc-comment",
+]
+
+[[package]]
+name = "clap-verbosity-flag"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0636f9c040082f8e161555a305f8cec1a1c2828b3d981c812b8c39f4ac00c42c"
+dependencies = [
+ "clap",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,5 @@ toml_edit = "0.14.4"
 cargo_metadata = "0.15.0"
 clap-cargo = { version = "0.9.1", features = ["cargo_metadata"] }
 ignore = "0.4.18"
+clap-verbosity-flag = "1.0.1"
+log = "0.4.17"

--- a/src/check_release.rs
+++ b/src/check_release.rs
@@ -113,7 +113,7 @@ pub(super) fn run_check_release(
 
     let version_change = get_semver_version_change(current_version, baseline_version)
         .unwrap_or_else(|| {
-            colored_ln(config.output_writer(), |w| {
+            colored_ln(config.stdout(), |w| {
                 colored!(
                     w,
                     "{}{}{:>12}{} Could not determine whether crate version changed. Assuming no change.",
@@ -147,7 +147,7 @@ pub(super) fn run_check_release(
     let skipped_queries = queries.len().saturating_sub(queries_to_run.len());
 
     if skipped_queries > 0 {
-        colored_ln(config.output_writer(), |w| {
+        colored_ln(config.stdout(), |w| {
             colored!(
                 w,
                 "{}{}{:>12}{} {}{}{} checks ({} checks skipped), version {} -> {} ({} change)",
@@ -166,7 +166,7 @@ pub(super) fn run_check_release(
         })
         .expect("print failed");
     } else {
-        colored_ln(config.output_writer(), |w| {
+        colored_ln(config.stdout(), |w| {
             colored!(
                 w,
                 "{}{}{:>12}{} {}{}{} checks, version {} -> {} ({} change)",
@@ -193,7 +193,7 @@ pub(super) fn run_check_release(
         };
         if config.printing_to_terminal() {
             colored!(
-                config.output_writer(),
+                config.stdout(),
                 "{}{}{:>12}{} [{:9}] {:^18} {}",
                 fg!(Some(Color::Cyan)),
                 bold!(true),
@@ -204,7 +204,7 @@ pub(super) fn run_check_release(
                 query_id,
             )
             .expect("print failed");
-            config.output_writer().flush().expect("flush failed");
+            config.stdout().flush().expect("flush failed");
         }
 
         let start_instant = std::time::Instant::now();
@@ -216,9 +216,9 @@ pub(super) fn run_check_release(
 
         if peeked.is_none() {
             if config.printing_to_terminal() {
-                write!(config.output_writer(), "\r").expect("print failed");
+                write!(config.stdout(), "\r").expect("print failed");
             }
-            colored_ln(config.output_writer(), |w| {
+            colored_ln(config.stdout(), |w| {
                 colored!(
                     w,
                     "{}{}{:>12}{} [{:>8.3}s] {:^18} {}",
@@ -236,9 +236,9 @@ pub(super) fn run_check_release(
             queries_with_errors.push(QueryWithResults::new(query_id.as_str(), results_iter));
 
             if config.printing_to_terminal() {
-                write!(config.output_writer(), "\r").expect("print failed");
+                write!(config.stdout(), "\r").expect("print failed");
             }
-            colored_ln(config.output_writer(), |w| {
+            colored_ln(config.stdout(), |w| {
                 colored!(
                     w,
                     "{}{}{:>12}{} [{:>8.3}s] {:^18} {}",
@@ -256,7 +256,7 @@ pub(super) fn run_check_release(
     }
 
     if !queries_with_errors.is_empty() {
-        colored_ln(config.output_writer(), |w| {
+        colored_ln(config.stdout(), |w| {
             colored!(
                 w,
                 "{}{}{:>12}{} [{:>8.3}s] {} checks run: {} passed, {} failed, {} skipped",
@@ -278,7 +278,7 @@ pub(super) fn run_check_release(
         for query_with_results in queries_with_errors {
             let semver_query = &queries[query_with_results.name];
             required_versions.push(semver_query.required_update);
-            colored_ln(config.output_writer(), |w| {
+            colored_ln(config.stdout(), |w| {
                 colored!(
                     w,
                     "\n--- failure {}: {} ---\n",
@@ -289,7 +289,7 @@ pub(super) fn run_check_release(
             .expect("print failed");
 
             if let Some(ref_link) = semver_query.reference_link.as_deref() {
-                colored_ln(config.output_writer(), |w| {
+                colored_ln(config.stdout(), |w| {
                     colored!(
                         w,
                         "{}Description:{}\n{}\n{:>12} {}\n{:>12} {}\n",
@@ -308,7 +308,7 @@ pub(super) fn run_check_release(
                 })
                 .expect("print failed");
             } else {
-                colored_ln(config.output_writer(), |w| {
+                colored_ln(config.stdout(), |w| {
                     colored!(
                         w,
                         "{}Description:{}\n{}\n{:>12} {}\n",
@@ -326,7 +326,7 @@ pub(super) fn run_check_release(
                 .expect("print failed");
             }
 
-            colored_ln(config.output_writer(), |w| {
+            colored_ln(config.stdout(), |w| {
                 colored!(w, "{}Failed in:{}", bold!(true), reset!(),)
             })
             .expect("print failed");
@@ -344,10 +344,10 @@ pub(super) fn run_check_release(
                         .render_template(template, &pretty_result)
                         .with_context(|| "Error instantiating semver query template.")
                         .expect("could not materialize template");
-                    colored_ln(config.output_writer(), |w| colored!(w, "  {}", message,))
+                    colored_ln(config.stdout(), |w| colored!(w, "  {}", message,))
                         .expect("print failed");
                 } else {
-                    colored_ln(config.output_writer(), |w| {
+                    colored_ln(config.stdout(), |w| {
                         colored!(
                             w,
                             "{}\n",
@@ -369,7 +369,7 @@ pub(super) fn run_check_release(
             unreachable!("{:?}", required_versions)
         };
 
-        colored_ln(config.output_writer(), |w| {
+        colored_ln(config.stdout(), |w| {
             colored!(
                 w,
                 "\n{}{}{:>12}{} [{:>8.3}s] semver requires new {} version: {} major and {} minor checks failed",
@@ -387,7 +387,7 @@ pub(super) fn run_check_release(
 
         Ok(false)
     } else {
-        colored_ln(config.output_writer(), |w| {
+        colored_ln(config.stdout(), |w| {
             colored!(
                 w,
                 "{}{}{:>12}{} [{:>8.3}s] {} checks run: {} passed, {} skipped",

--- a/src/check_release.rs
+++ b/src/check_release.rs
@@ -193,7 +193,7 @@ pub(super) fn run_check_release(
             RequiredSemverUpdate::Major => "major",
             RequiredSemverUpdate::Minor => "minor",
         };
-        if config.printing_to_terminal() {
+        if config.is_stdout_tty() {
             colored!(
                 config.stdout(),
                 "{}{}{:>12}{} [{:9}] {:^18} {}",
@@ -217,7 +217,7 @@ pub(super) fn run_check_release(
         total_duration += time_to_decide;
 
         if peeked.is_none() {
-            if config.printing_to_terminal() {
+            if config.is_stdout_tty() {
                 write!(config.stdout(), "\r").expect("print failed");
             }
             colored_ln(config.stdout(), |w| {
@@ -237,7 +237,7 @@ pub(super) fn run_check_release(
         } else {
             queries_with_errors.push(QueryWithResults::new(query_id.as_str(), results_iter));
 
-            if config.printing_to_terminal() {
+            if config.is_stdout_tty() {
                 write!(config.stdout(), "\r").expect("print failed");
             }
             colored_ln(config.stdout(), |w| {

--- a/src/check_release.rs
+++ b/src/check_release.rs
@@ -105,9 +105,11 @@ fn make_result_iter<'a>(
 
 pub(super) fn run_check_release(
     config: &mut GlobalConfig,
+    crate_name: &str,
     current_crate: Crate,
     baseline_crate: Crate,
 ) -> anyhow::Result<bool> {
+    config.shell_status("Checking", crate_name)?;
     let current_version = current_crate.crate_version.as_deref();
     let baseline_version = baseline_crate.crate_version.as_deref();
 

--- a/src/check_release.rs
+++ b/src/check_release.rs
@@ -115,7 +115,7 @@ pub(super) fn run_check_release(
 
     let version_change = get_semver_version_change(current_version, baseline_version)
         .unwrap_or_else(|| {
-            colored_ln(config.stdout(), |w| {
+            colored_ln(config.stderr(), |w| {
                 colored!(
                     w,
                     "{}{}{:>12}{} Could not determine whether crate version changed. Assuming no change.",
@@ -149,7 +149,7 @@ pub(super) fn run_check_release(
     let skipped_queries = queries.len().saturating_sub(queries_to_run.len());
 
     if skipped_queries > 0 {
-        colored_ln(config.stdout(), |w| {
+        colored_ln(config.stderr(), |w| {
             colored!(
                 w,
                 "{}{}{:>12}{} {}{}{} checks ({} checks skipped), version {} -> {} ({} change)",
@@ -168,7 +168,7 @@ pub(super) fn run_check_release(
         })
         .expect("print failed");
     } else {
-        colored_ln(config.stdout(), |w| {
+        colored_ln(config.stderr(), |w| {
             colored!(
                 w,
                 "{}{}{:>12}{} {}{}{} checks, version {} -> {} ({} change)",
@@ -193,9 +193,9 @@ pub(super) fn run_check_release(
             RequiredSemverUpdate::Major => "major",
             RequiredSemverUpdate::Minor => "minor",
         };
-        if config.is_stdout_tty() {
+        if config.is_stderr_tty() {
             colored!(
-                config.stdout(),
+                config.stderr(),
                 "{}{}{:>12}{} [{:9}] {:^18} {}",
                 fg!(Some(Color::Cyan)),
                 bold!(true),
@@ -206,7 +206,7 @@ pub(super) fn run_check_release(
                 query_id,
             )
             .expect("print failed");
-            config.stdout().flush().expect("flush failed");
+            config.stderr().flush().expect("flush failed");
         }
 
         let start_instant = std::time::Instant::now();
@@ -217,10 +217,10 @@ pub(super) fn run_check_release(
         total_duration += time_to_decide;
 
         if peeked.is_none() {
-            if config.is_stdout_tty() {
-                write!(config.stdout(), "\r").expect("print failed");
+            if config.is_stderr_tty() {
+                write!(config.stderr(), "\r").expect("print failed");
             }
-            colored_ln(config.stdout(), |w| {
+            colored_ln(config.stderr(), |w| {
                 colored!(
                     w,
                     "{}{}{:>12}{} [{:>8.3}s] {:^18} {}",
@@ -237,10 +237,10 @@ pub(super) fn run_check_release(
         } else {
             queries_with_errors.push(QueryWithResults::new(query_id.as_str(), results_iter));
 
-            if config.is_stdout_tty() {
-                write!(config.stdout(), "\r").expect("print failed");
+            if config.is_stderr_tty() {
+                write!(config.stderr(), "\r").expect("print failed");
             }
-            colored_ln(config.stdout(), |w| {
+            colored_ln(config.stderr(), |w| {
                 colored!(
                     w,
                     "{}{}{:>12}{} [{:>8.3}s] {:^18} {}",
@@ -258,7 +258,7 @@ pub(super) fn run_check_release(
     }
 
     if !queries_with_errors.is_empty() {
-        colored_ln(config.stdout(), |w| {
+        colored_ln(config.stderr(), |w| {
             colored!(
                 w,
                 "{}{}{:>12}{} [{:>8.3}s] {} checks run: {} passed, {} failed, {} skipped",
@@ -371,7 +371,7 @@ pub(super) fn run_check_release(
             unreachable!("{:?}", required_versions)
         };
 
-        colored_ln(config.stdout(), |w| {
+        colored_ln(config.stderr(), |w| {
             colored!(
                 w,
                 "\n{}{}{:>12}{} [{:>8.3}s] semver requires new {} version: {} major and {} minor checks failed",
@@ -389,7 +389,7 @@ pub(super) fn run_check_release(
 
         Ok(false)
     } else {
-        colored_ln(config.stdout(), |w| {
+        colored_ln(config.stderr(), |w| {
             colored!(
                 w,
                 "{}{}{:>12}{} [{:>8.3}s] {} checks run: {} passed, {} skipped",

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use crate::templating::make_handlebars_registry;
 
 #[allow(dead_code)]
 pub(crate) struct GlobalConfig {
-    is_stdout_tty: bool,
+    is_stderr_tty: bool,
     stdout: StandardStream,
     stderr: StandardStream,
     handlebars: handlebars::Handlebars<'static>,
@@ -24,7 +24,7 @@ impl GlobalConfig {
         };
 
         Self {
-            is_stdout_tty,
+            is_stderr_tty,
             stdout: StandardStream::stdout(color_choice.unwrap_or_else(|| {
                 if is_stdout_tty {
                     ColorChoice::Auto
@@ -47,8 +47,8 @@ impl GlobalConfig {
         &self.handlebars
     }
 
-    pub fn is_stdout_tty(&self) -> bool {
-        self.is_stdout_tty
+    pub fn is_stderr_tty(&self) -> bool {
+        self.is_stderr_tty
     }
 
     pub fn stdout(&mut self) -> &mut StandardStream {

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use crate::templating::make_handlebars_registry;
 #[allow(dead_code)]
 pub(crate) struct GlobalConfig {
     printing_to_terminal: bool,
-    output_writer: StandardStream,
+    stdout: StandardStream,
     handlebars: handlebars::Handlebars<'static>,
 }
 
@@ -29,7 +29,7 @@ impl GlobalConfig {
 
         Self {
             printing_to_terminal,
-            output_writer: StandardStream::stdout(color_choice),
+            stdout: StandardStream::stdout(color_choice),
             handlebars: make_handlebars_registry(),
         }
     }
@@ -38,8 +38,8 @@ impl GlobalConfig {
         self.printing_to_terminal
     }
 
-    pub fn output_writer(&mut self) -> &mut StandardStream {
-        &mut self.output_writer
+    pub fn stdout(&mut self) -> &mut StandardStream {
+        &mut self.stdout
     }
 
     pub fn handlebars(&self) -> &handlebars::Handlebars<'static> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,48 @@
+use termcolor::{ColorChoice, StandardStream};
+
+use crate::templating::make_handlebars_registry;
+
+#[allow(dead_code)]
+pub(crate) struct GlobalConfig {
+    printing_to_terminal: bool,
+    output_writer: StandardStream,
+    handlebars: handlebars::Handlebars<'static>,
+}
+
+impl GlobalConfig {
+    pub fn new() -> Self {
+        let printing_to_terminal = atty::is(atty::Stream::Stdout);
+
+        let color_choice = match std::env::var("CARGO_TERM_COLOR").as_deref() {
+            Ok("always") => ColorChoice::Always,
+            Ok("alwaysansi") => ColorChoice::AlwaysAnsi,
+            Ok("auto") => ColorChoice::Auto,
+            Ok("never") => ColorChoice::Never,
+            Ok(_) | Err(..) => {
+                if printing_to_terminal {
+                    ColorChoice::Auto
+                } else {
+                    ColorChoice::Never
+                }
+            }
+        };
+
+        Self {
+            printing_to_terminal,
+            output_writer: StandardStream::stdout(color_choice),
+            handlebars: make_handlebars_registry(),
+        }
+    }
+
+    pub fn printing_to_terminal(&self) -> bool {
+        self.printing_to_terminal
+    }
+
+    pub fn output_writer(&mut self) -> &mut StandardStream {
+        &mut self.output_writer
+    }
+
+    pub fn handlebars(&self) -> &handlebars::Handlebars<'static> {
+        &self.handlebars
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use crate::templating::make_handlebars_registry;
 
 #[allow(dead_code)]
 pub(crate) struct GlobalConfig {
+    level: Option<log::Level>,
     is_stderr_tty: bool,
     stdout: StandardStream,
     stderr: StandardStream,
@@ -24,6 +25,7 @@ impl GlobalConfig {
         };
 
         Self {
+            level: None,
             is_stderr_tty,
             stdout: StandardStream::stdout(color_choice.unwrap_or_else(|| {
                 if is_stdout_tty {
@@ -45,6 +47,15 @@ impl GlobalConfig {
 
     pub fn handlebars(&self) -> &handlebars::Handlebars<'static> {
         &self.handlebars
+    }
+
+    pub fn set_level(mut self, level: Option<log::Level>) -> Self {
+        self.level = level;
+        self
+    }
+
+    pub fn is_verbose(&self) -> bool {
+        log::Level::Debug <= self.level.unwrap_or(log::Level::Error)
     }
 
     pub fn is_stderr_tty(&self) -> bool {

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use crate::templating::make_handlebars_registry;
 
 #[allow(dead_code)]
 pub(crate) struct GlobalConfig {
-    printing_to_terminal: bool,
+    is_stdout_tty: bool,
     stdout: StandardStream,
     stderr: StandardStream,
     handlebars: handlebars::Handlebars<'static>,
@@ -12,7 +12,7 @@ pub(crate) struct GlobalConfig {
 
 impl GlobalConfig {
     pub fn new() -> Self {
-        let printing_to_terminal = atty::is(atty::Stream::Stdout);
+        let is_stdout_tty = atty::is(atty::Stream::Stdout);
 
         let color_choice = match std::env::var("CARGO_TERM_COLOR").as_deref() {
             Ok("always") => ColorChoice::Always,
@@ -20,7 +20,7 @@ impl GlobalConfig {
             Ok("auto") => ColorChoice::Auto,
             Ok("never") => ColorChoice::Never,
             Ok(_) | Err(..) => {
-                if printing_to_terminal {
+                if is_stdout_tty {
                     ColorChoice::Auto
                 } else {
                     ColorChoice::Never
@@ -29,7 +29,7 @@ impl GlobalConfig {
         };
 
         Self {
-            printing_to_terminal,
+            is_stdout_tty,
             stdout: StandardStream::stdout(color_choice),
             stderr: StandardStream::stderr(color_choice),
             handlebars: make_handlebars_registry(),
@@ -40,8 +40,8 @@ impl GlobalConfig {
         &self.handlebars
     }
 
-    pub fn printing_to_terminal(&self) -> bool {
-        self.printing_to_terminal
+    pub fn is_stdout_tty(&self) -> bool {
+        self.is_stdout_tty
     }
 
     pub fn stdout(&mut self) -> &mut StandardStream {

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,16 @@ impl GlobalConfig {
         log::Level::Debug <= self.level.unwrap_or(log::Level::Error)
     }
 
+    pub fn verbose(
+        &mut self,
+        callback: impl Fn(&mut Self) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        if self.is_verbose() {
+            callback(self)?;
+        }
+        Ok(())
+    }
+
     pub fn is_stderr_tty(&self) -> bool {
         self.is_stderr_tty
     }
@@ -108,5 +118,9 @@ impl GlobalConfig {
         message: impl std::fmt::Display,
     ) -> anyhow::Result<()> {
         self.shell_print(action, message, termcolor::Color::Green, true)
+    }
+
+    pub fn shell_warn(&mut self, message: impl std::fmt::Display) -> anyhow::Result<()> {
+        self.shell_print("warning", message, termcolor::Color::Yellow, false)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 pub mod adapter;
 mod baseline;
 mod check_release;
+mod config;
 mod dump;
 pub mod indexed_crate;
 mod manifest;
@@ -13,45 +14,9 @@ mod util;
 use std::path::PathBuf;
 
 use clap::{ArgGroup, Args, Parser, Subcommand};
-use termcolor::{ColorChoice, StandardStream};
 
-use crate::{
-    check_release::run_check_release, templating::make_handlebars_registry,
-    util::load_rustdoc_from_file,
-};
-
-#[allow(dead_code)]
-pub(crate) struct GlobalConfig {
-    printing_to_terminal: bool,
-    output_writer: StandardStream,
-    handlebars: handlebars::Handlebars<'static>,
-}
-
-impl GlobalConfig {
-    fn new() -> Self {
-        let printing_to_terminal = atty::is(atty::Stream::Stdout);
-
-        let color_choice = match std::env::var("CARGO_TERM_COLOR").as_deref() {
-            Ok("always") => ColorChoice::Always,
-            Ok("alwaysansi") => ColorChoice::AlwaysAnsi,
-            Ok("auto") => ColorChoice::Auto,
-            Ok("never") => ColorChoice::Never,
-            Ok(_) | Err(..) => {
-                if printing_to_terminal {
-                    ColorChoice::Auto
-                } else {
-                    ColorChoice::Never
-                }
-            }
-        };
-
-        Self {
-            printing_to_terminal,
-            output_writer: StandardStream::stdout(color_choice),
-            handlebars: make_handlebars_registry(),
-        }
-    }
-}
+use crate::{check_release::run_check_release, util::load_rustdoc_from_file};
+use config::GlobalConfig;
 
 fn main() -> anyhow::Result<()> {
     let Cargo::SemverChecks(args) = Cargo::parse();

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -5,7 +5,13 @@ pub fn get_package_name(manifest_path: &std::path::Path) -> anyhow::Result<Strin
     let manifest: toml_edit::Document = manifest
         .parse()
         .map_err(|e| anyhow::format_err!("Failed to parse {}: {}", manifest_path.display(), e))?;
-    let crate_name = manifest["package"]["name"].as_str().ok_or_else(|| {
+    let package = manifest.get("package").ok_or_else(|| {
+        anyhow::format_err!(
+            "Failed to parse {}: no `package` table",
+            manifest_path.display()
+        )
+    })?;
+    let crate_name = package["name"].as_str().ok_or_else(|| {
         anyhow::format_err!(
             "Failed to parse {}: invalid package.name",
             manifest_path.display()


### PR DESCRIPTION
Main changes
- Move status messages to stderr
- rustdoc output is now behind `--verbose`'
- For users concerned over long rustdoc run without output, we now print a status message for it
- Add crate name to per-crate start message
- Put per-crate check counts behind `--verbose`
- Put each check's run behind `--verbose`

To more easily match cargo's behavior (and make it easier to integrate with cargo in the future), this uses an API inspired by `cargo::core::Shell` to manage common message formats and behavior.  This was pulled out of cargo-edit.