### PR TITLE
chore(gh): Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,30 @@
+name: Bug report
+description: Things didn't meet expectations
+labels: 'C-bug'
+body:
+  - type: textarea
+    attributes:
+      label: Steps to reproduce the bug with the above code
+      description: A command like `cargo run -- options...` or multiple commands.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Actual Behaviour
+      description: When I do like *this*, *that* is happening and I think it shouldn't.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected Behaviour
+      description: I think *this* should happen instead.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional Context
+      description: Add any other context about the problem here.
+  - type: textarea
+    attributes:
+      label: Debug Output
+      description: "Run `cargo semver-checks --bugreport`'

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: Feature request
+description: Raising expectations
+labels: 'C-enhancement'
+body:
+  - type: textarea
+    attributes:
+      label: Describe your use case
+      description: Describe the problem you're trying to solve. This is not mandatory and we *do* consider features without a specific use case, but real problems have priority.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe the solution you'd like
+      description: Please explain what the wanted solution should look like. You are **strongly encouraged** to attach a snippet of (pseudo)code.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Alternatives, if applicable
+      description: A clear and concise description of any alternative solutions or features you've managed to come up with.
+  - type: textarea
+    attributes:
+      label: Additional Context
+      description: Add any other context about the feature request here.


### PR DESCRIPTION
The main goal is to raise awareness of `--bugreport` once its released.