### PR TITLE
fix(query): Distinguish between description and reference

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -120,6 +120,10 @@ impl GlobalConfig {
         self.shell_print(action, message, termcolor::Color::Green, true)
     }
 
+    pub fn shell_note(&mut self, message: impl std::fmt::Display) -> anyhow::Result<()> {
+        self.shell_print("note", message, termcolor::Color::Cyan, false)
+    }
+
     pub fn shell_warn(&mut self, message: impl std::fmt::Display) -> anyhow::Result<()> {
         self.shell_print("warning", message, termcolor::Color::Yellow, false)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,9 @@ fn main() -> anyhow::Result<()> {
                 row[0], widths[0], row[1], widths[1], row[2], widths[2]
             )?;
         }
+
+        let mut config = GlobalConfig::new().set_level(args.verbosity.log_level());
+        config.shell_note("Use `--explain <id>` to see more details")?;
         std::process::exit(0);
     } else if let Some(id) = args.explain.as_deref() {
         let queries = query::SemverQuery::all_queries();
@@ -212,6 +215,9 @@ struct SemverChecks {
 
     #[clap(long, global = true, exclusive = true)]
     list: bool,
+
+    #[clap(flatten)]
+    verbosity: clap_verbosity_flag::Verbosity<clap_verbosity_flag::InfoLevel>,
 
     #[clap(subcommand)]
     command: Option<SemverChecksCommands>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,14 +39,19 @@ fn main() -> anyhow::Result<()> {
         std::process::exit(0);
     } else if args.list {
         let queries = query::SemverQuery::all_queries();
-        let mut rows = vec![["id", "type"], ["==", "===="]];
+        let mut rows = vec![["id", "type", "description"], ["==", "====", "==========="]];
         for query in queries.values() {
-            rows.push([query.id.as_str(), query.required_update.as_str()]);
+            rows.push([
+                query.id.as_str(),
+                query.required_update.as_str(),
+                query.description.as_str(),
+            ]);
         }
-        let mut widths = [0; 2];
+        let mut widths = [0; 3];
         for row in &rows {
             widths[0] = widths[0].max(row[0].len());
             widths[1] = widths[1].max(row[1].len());
+            widths[2] = widths[2].max(row[2].len());
         }
         let stdout = std::io::stdout();
         let mut stdout = stdout.lock();
@@ -54,8 +59,8 @@ fn main() -> anyhow::Result<()> {
             use std::io::Write;
             writeln!(
                 stdout,
-                "{0:<1$} {2:<3$}",
-                row[0], widths[0], row[1], widths[1],
+                "{0:<1$} {2:<3$} {4:<5$}",
+                row[0], widths[0], row[1], widths[1], row[2], widths[2]
             )?;
         }
         std::process::exit(0);
@@ -69,7 +74,13 @@ fn main() -> anyhow::Result<()> {
                 ids.join("\n  ")
             )
         })?;
-        println!("{}", query.description);
+        println!(
+            "{}",
+            query
+                .reference
+                .as_deref()
+                .unwrap_or_else(|| query.description.as_str())
+        );
         if let Some(link) = &query.reference_link {
             println!();
             println!("See also {}", link);

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,7 @@ fn main() -> anyhow::Result<()> {
             query
                 .reference
                 .as_deref()
-                .unwrap_or_else(|| query.description.as_str())
+                .unwrap_or(query.description.as_str())
         );
         if let Some(link) = &query.reference_link {
             println!();

--- a/src/queries/auto_trait_impl_removed.ron
+++ b/src/queries/auto_trait_impl_removed.ron
@@ -1,7 +1,7 @@
 SemverQuery(
     id: "auto_trait_impl_removed",
     human_readable_name: "auto trait no longer implemented",
-    description: "A public type has stopped implementing one or more auto traits.",
+    description: "A type has stopped implementing one or more auto traits.",
     required_update: Major,
     // TODO: Add a better reference link once the cargo semver reference has a section on auto traits.
     reference_link: Some("https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits"),

--- a/src/queries/derive_trait_impl_removed.ron
+++ b/src/queries/derive_trait_impl_removed.ron
@@ -1,7 +1,7 @@
 SemverQuery(
     id: "derive_trait_impl_removed",
     human_readable_name: "built-in derived trait no longer implemented",
-    description: "A public type has stopped implementing one or more built-in traits that used to be derived.",
+    description: "A type has stopped implementing a built-in trait that used to be derived.",
     required_update: Major,
     // TODO: Find a better reference than the definition of #[derive(...)].
     //       The cargo semver reference doesn't say that no longer deriving a pub trait is breaking.

--- a/src/queries/enum_missing.ron
+++ b/src/queries/enum_missing.ron
@@ -1,7 +1,7 @@
 SemverQuery(
     id: "enum_missing",
     human_readable_name: "pub enum removed or renamed",
-    description: "A publicly-visible enum can no longer be imported by its prior path, which is a major breaking change for code that depends on it.",
+    description: "An enum can no longer be imported by its prior path.",
     required_update: Major,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
     query: r#"

--- a/src/queries/enum_repr_c_removed.ron
+++ b/src/queries/enum_repr_c_removed.ron
@@ -1,7 +1,8 @@
 SemverQuery(
     id: "enum_repr_c_removed",
     human_readable_name: "enum repr(C) removed",
-    description: "A enum that used to be repr(C) is no longer repr(C). This can cause its memory layout to change, breaking FFI use cases.",
+    description: "An enum that used to be repr(C) is no longer repr(C).",
+    reference: Some("An enum that used to be repr(C) is no longer repr(C). This can cause its memory layout to change, breaking FFI use cases."),
     required_update: Major,
 
     // TODO: Change the reference link to point to the cargo semver reference

--- a/src/queries/enum_repr_int_changed.ron
+++ b/src/queries/enum_repr_int_changed.ron
@@ -1,7 +1,8 @@
 SemverQuery(
     id: "enum_repr_int_changed",
     human_readable_name: "enum repr(u*)/repr(i*) changed",
-    description: "The repr(u*) or repr(i*) attribute on an enum was changed to another integer type. This can cause its memory representation to change, breaking FFI use cases.",
+    description: "An enum's repr attribute changed integer types.",
+    reference: Some("The repr(u*) or repr(i*) attribute on an enum was changed to another integer type. This can cause its memory representation to change, breaking FFI use cases."),
     required_update: Major,
 
     // TODO: Change the reference link to point to the cargo semver reference

--- a/src/queries/enum_repr_int_removed.ron
+++ b/src/queries/enum_repr_int_removed.ron
@@ -1,7 +1,8 @@
 SemverQuery(
     id: "enum_repr_int_removed",
     human_readable_name: "enum repr(u*)/repr(i*) removed",
-    description: "The repr(u*) or repr(i*) attribute was removed from an enum. This can cause its memory representation to change, breaking FFI use cases.",
+    description: "An enum's repr attribute was removed.",
+    reference: Some("The repr(u*) or repr(i*) attribute was removed from an enum. This can cause its memory representation to change, breaking FFI use cases."),
     required_update: Major,
 
     // TODO: Change the reference link to point to the cargo semver reference

--- a/src/queries/enum_variant_added.ron
+++ b/src/queries/enum_variant_added.ron
@@ -1,7 +1,7 @@
 SemverQuery(
     id: "enum_variant_added",
     human_readable_name: "enum variant added on exhaustive enum",
-    description: "A publicly-visible enum has a new variant. The enum is not marked #[non_exhaustive], so this is a major breaking change for code that depends on it.",
+    description: "An exhaustive enum has a new variant.",
     required_update: Major,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new"),
     query: r#"

--- a/src/queries/enum_variant_missing.ron
+++ b/src/queries/enum_variant_missing.ron
@@ -1,7 +1,7 @@
 SemverQuery(
     id: "enum_variant_missing",
     human_readable_name: "pub enum variant removed or renamed",
-    description: "A publicly-visible enum has at least one variant that is no longer available under its prior name, which is a major breaking change for code that depends on it.",
+    description: "An enum variant is no longer available under its prior name.",
     required_update: Major,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
     query: r#"

--- a/src/queries/function_missing.ron
+++ b/src/queries/function_missing.ron
@@ -1,7 +1,7 @@
 SemverQuery(
     id: "function_missing",
     human_readable_name: "pub fn removed or renamed",
-    description: "A publicly-visible function can no longer be imported by its prior path, which is a major breaking change for code that depends on it.",
+    description: "A function can no longer be imported by its prior path.",
     required_update: Major,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
     query: r#"

--- a/src/queries/inherent_method_missing.ron
+++ b/src/queries/inherent_method_missing.ron
@@ -1,7 +1,7 @@
 SemverQuery(
     id: "inherent_method_missing",
     human_readable_name: "pub method removed or renamed",
-    description: "A publicly-visible method or associated fn is no longer available under its prior name, which is a major breaking change for code that depends on it.",
+    description: "A method or associated fn is no longer available under its prior name.",
     required_update: Major,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
     query: r#"

--- a/src/queries/sized_impl_removed.ron
+++ b/src/queries/sized_impl_removed.ron
@@ -1,7 +1,7 @@
 SemverQuery(
     id: "sized_impl_removed",
     human_readable_name: "Sized no longer implemented",
-    description: "A public type is no longer Sized.",
+    description: "A type is no longer `Sized`.",
     required_update: Major,
     // TODO: Add a better reference link once the cargo semver reference has a section on Sized.
     reference_link: Some("https://doc.rust-lang.org/reference/special-types-and-traits.html#sized"),

--- a/src/queries/struct_marked_non_exhaustive.ron
+++ b/src/queries/struct_marked_non_exhaustive.ron
@@ -1,7 +1,8 @@
 SemverQuery(
     id: "struct_marked_non_exhaustive",
     human_readable_name: "struct marked #[non_exhaustive]",
-    description: "A publicly-visible struct has been marked #[non_exhaustive], but it was previously constructible using a struct literal outside its crate. The #[non_exhaustive] attribute disables that, so this is a major breaking change for code that depends on it.",
+    description: "An exhaustive struct has been marked #[non_exhaustive].",
+    reference: Some("An exhaustive struct has been marked #[non_exhaustive] making it no longer constructible using a struct literal outside its crate."),
     required_update: Major,
 
     // TODO: Change the reference link once this cargo docs PR merges:

--- a/src/queries/struct_missing.ron
+++ b/src/queries/struct_missing.ron
@@ -1,7 +1,7 @@
 SemverQuery(
     id: "struct_missing",
     human_readable_name: "pub struct removed or renamed",
-    description: "A publicly-visible struct can no longer be imported by its prior path, which is a major breaking change for code that depends on it.",
+    description: "A struct can no longer be imported by its prior path.",
     required_update: Major,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
     query: r#"

--- a/src/queries/struct_pub_field_missing.ron
+++ b/src/queries/struct_pub_field_missing.ron
@@ -1,7 +1,7 @@
 SemverQuery(
     id: "struct_pub_field_missing",
     human_readable_name: "pub struct's pub field removed or renamed",
-    description: "A publicly-visible struct has at least one public field that is no longer available under its prior name, which is a major breaking change for code that depends on it.",
+    description: "A struct field is no longer available under its prior name.",
     required_update: Major,
     reference_link: Some("https://doc.rust-lang.org/cargo/reference/semver.html#item-remove"),
     query: r#"

--- a/src/queries/struct_repr_c_removed.ron
+++ b/src/queries/struct_repr_c_removed.ron
@@ -1,7 +1,8 @@
 SemverQuery(
     id: "struct_repr_c_removed",
     human_readable_name: "struct repr(C) removed",
-    description: "A struct that used to be repr(C) is no longer repr(C). This can cause its memory layout to change, breaking FFI use cases.",
+    description: "A struct that used to be repr(C) is no longer repr(C).",
+    reference: Some("A struct that used to be repr(C) is no longer repr(C). This can cause its memory layout to change, breaking FFI use cases."),
     required_update: Major,
 
     // TODO: Change the reference link to point to the cargo semver reference

--- a/src/queries/struct_repr_transparent_removed.ron
+++ b/src/queries/struct_repr_transparent_removed.ron
@@ -1,7 +1,8 @@
 SemverQuery(
     id: "struct_repr_transparent_removed",
     human_readable_name: "struct repr(transparent) removed",
-    description: r#"
+    description: "A struct is no longer repr(transparent).",
+    reference: Some(r#"
 repr(transparent) was removed from a struct. This can cause its memory layout to change,
 breaking FFI use cases.
 
@@ -23,7 +24,7 @@ To avoid false-positives, this query is restricted to checking only structs that
 - are repr(transparent);
 - have exactly one field that isn't PhantomData, and
 - that one field is public.
-"#,
+"#),
     required_update: Major,
 
     // TODO: Change the reference link to point to the cargo semver reference

--- a/src/queries/unit_struct_changed_kind.ron
+++ b/src/queries/unit_struct_changed_kind.ron
@@ -1,7 +1,8 @@
 SemverQuery(
     id: "unit_struct_changed_kind",
     human_readable_name: "unit struct changed kind",
-    description: "A public struct that was previously a unit struct is now a plain struct. The unit struct was not marked #[non_exhaustive], so it could be constructed outside of the defining crate. Plain structs cannot be constructed using the syntax allowed for unit structs, so this is a major breaking change for code that depends on it.",
+    description: "A struct changed from a unit struct to a plain struct.",
+    reference: Some("A public struct that was previously a unit struct is now a plain struct. The unit struct was not marked #[non_exhaustive], so it could be constructed outside of the defining crate. Plain structs cannot be constructed using the syntax allowed for unit structs, so this is a major breaking change for code that depends on it."),
     required_update: Major,
 
     // TODO: Change the reference link once this cargo docs PR merges:

--- a/src/queries/variant_marked_non_exhaustive.ron
+++ b/src/queries/variant_marked_non_exhaustive.ron
@@ -1,7 +1,8 @@
 SemverQuery(
     id: "variant_marked_non_exhaustive",
     human_readable_name: "enum variant marked #[non_exhaustive]",
-    description: "An enum variant has been marked #[non_exhaustive] for the first time, preventing it from being constructed using a literal from outside its own crate. This is a major breaking change for code that depends on it.",
+    description: "An exhaustive enum variant has been marked #[non_exhaustive].",
+    reference: Some("An exhaustive enum variant has been marked #[non_exhaustive], preventing it from being constructed using a literal from outside its own crate."),
     required_update: Major,
 
     // TODO: Change the reference link once this cargo docs PR merges:

--- a/src/query.rs
+++ b/src/query.rs
@@ -50,6 +50,9 @@ pub(crate) struct SemverQuery {
     pub(crate) required_update: RequiredSemverUpdate,
 
     #[serde(default)]
+    pub(crate) reference: Option<String>,
+
+    #[serde(default)]
     pub(crate) reference_link: Option<String>,
 
     pub(crate) query: String,
@@ -93,7 +96,16 @@ impl SemverQuery {
             include_str!("./queries/variant_marked_non_exhaustive.ron"),
         ];
         for query_text in query_text_contents {
-            let query: SemverQuery = ron::from_str(query_text).expect("query failed to parse");
+            let query: SemverQuery = ron::from_str(query_text).unwrap_or_else(|e| {
+                panic!(
+                    "\
+Failed to parse a query: {}
+```ron
+{}
+```",
+                    e, query_text
+                );
+            });
             let id_conflict = queries.insert(query.id.clone(), query);
             assert!(id_conflict.is_none(), "{:?}", id_conflict);
         }


### PR DESCRIPTION
This is a follow up to #109 so we can show descriptions in `--list`.  In doing this, I was considering if we should have any hint that `--explain` would be useful but I opted to instead just remind the user of `--explain`.

Note on the description style
- It is now consistently singular indefinite article
- It puts the relevant API item first
- It consistently leaves off "public" / "publicly-visible" as those are assumed