### PR TITLE
fix(cli): Allow using current version as baseline

### DIFF
--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -214,7 +214,9 @@ impl BaselineLoader for RegistryBaseline {
                 .versions()
                 .iter()
                 .filter_map(|i| semver::Version::parse(i.version()).ok())
-                .filter(|v| v < current)
+                // For unpublished changes when the user doesn't increment the version
+                // post-release, allow using the current version as a baseline.
+                .filter(|v| v <= current)
                 .collect::<Vec<_>>();
             instances.sort();
             let instance = instances

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -222,7 +222,9 @@ impl BaselineLoader for RegistryBaseline {
                 .rev()
                 .find(|v| v.pre.is_empty())
                 .or_else(|| instances.last())
-                .with_context(|| anyhow::format_err!("No published versions for {}", name))?;
+                .with_context(|| {
+                    anyhow::format_err!("No available baseline versions for {}@{}", name, current)
+                })?;
             instance.to_string()
         } else {
             let instance = crate_


### PR DESCRIPTION
In most cases, people do not bump the version post-release so the
current version in the manifest is actually the baseline.

This will cause problems when we add support for running against
dependencies but I think that can be resolved by only doing `<=` for
workspace members and `<` for everything else.

For more on why not to do a post-release version bump, see crate-ci/cargo-release#82

Fixes #118