### PR TITLE
Persist the git credentials in the publishing steps.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Tag the version
         run: |


### PR DESCRIPTION
The `git push` step for the tag requires write access to the repo. Make the checkout action persist its credentials to make that work.
