### PR TITLE
Add support for rustdoc JSON format v21.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,9 +983,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustdoc-types"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d1ecdf1172107d4fc7001f47259299641298a67347c59a0e4216af7b6618c8"
+checksum = "a61fb498f838b7da375722c088e3c2571c3fbe7fe38c8fa208a6de1a6fdc3907"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["command-line-utilities", "development-tools::cargo-plugins"]
 
 [dependencies]
 trustfall_core = "0.0.4"
-rustdoc-types = "0.15.0"
+rustdoc-types = "0.17.0"
 clap = { version = "3.2.8", features = ["derive", "cargo"] }
 serde_json = "1.0.82"
 anyhow = "1.0.58"

--- a/src/indexed_crate.rs
+++ b/src/indexed_crate.rs
@@ -105,9 +105,15 @@ fn collect_public_items<'a>(
                     }
                 }
                 rustdoc_types::ItemEnum::Struct(struct_) => {
-                    for inner in struct_
-                        .fields
-                        .iter()
+                    let field_ids_iter: Box<dyn Iterator<Item = &Id>> = match &struct_.kind {
+                        rustdoc_types::StructKind::Unit => Box::new(std::iter::empty()),
+                        rustdoc_types::StructKind::Tuple(field_ids) => {
+                            Box::new(field_ids.iter().filter_map(|x| x.as_ref()))
+                        }
+                        rustdoc_types::StructKind::Plain { fields, .. } => Box::new(fields.iter()),
+                    };
+
+                    for inner in field_ids_iter
                         .chain(struct_.impls.iter())
                         .filter_map(|id| crate_.index.get(id))
                     {


### PR DESCRIPTION
Resolves #127.

Required starting at or slightly before `rust version 1.65.0-nightly (1120c5e01 2022-09-08)`.
