### PR TITLE
Prototype for simultaneous support of multiple rustdoc format versions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,8 @@ dependencies = [
  "ignore",
  "log",
  "ron 0.7.1",
- "rustdoc-types",
+ "rustdoc-types 0.14.0",
+ "rustdoc-types 0.17.0",
  "semver",
  "serde",
  "serde_json",
@@ -980,6 +981,15 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustdoc-types"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb8ae6df9a4006b7968781abb9a2ea2983b5f3cad2ca9294d195781618194c28"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "rustdoc-types"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ categories = ["command-line-utilities", "development-tools::cargo-plugins"]
 
 [dependencies]
 trustfall_core = "0.0.4"
-rustdoc-types = "0.17.0"
+rustdoc-types-14 = { package = "rustdoc-types", version = "0.14.0" }
+rustdoc-types-17 = { package = "rustdoc-types", version = "0.17.0" }
 clap = { version = "3.2.8", features = ["derive", "cargo"] }
 serde_json = "1.0.82"
 anyhow = "1.0.58"

--- a/scripts/regenerate_test_rustdocs.sh
+++ b/scripts/regenerate_test_rustdocs.sh
@@ -15,7 +15,7 @@ mkdir -p "$TARGET_DIR"
 
 # Make the baseline configuration file.
 echo "Generating: baseline"
-cargo +nightly rustdoc -- -Zunstable-options --output-format json
+cargo +nightly-2022-08-30 rustdoc -- -Zunstable-options --output-format json
 mv "$RUSTDOC_OUTPUT" "$TARGET_DIR/baseline.json"
 
 # For each feature, re-run rustdoc with it enabled.
@@ -23,7 +23,7 @@ features="$(cargo metadata --format-version 1 | \
     jq --exit-status -r '.packages[] | select(.name = "semver_tests") | .features | keys[]')"
 while IFS= read -r feat; do
     echo "Generating: $feat"
-    cargo +nightly rustdoc --features "$feat" -- -Zunstable-options --output-format json
+    cargo +nightly-2022-08-30 rustdoc --features "$feat" -- -Zunstable-options --output-format json
     mv "$RUSTDOC_OUTPUT" "$TARGET_DIR/$feat.json"
 done <<< "$features"
 

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -1,0 +1,78 @@
+use std::{collections::BTreeMap, sync::Arc, iter::Peekable, cell::RefCell, rc::Rc};
+
+use anyhow::Context;
+use trustfall_core::{frontend::parse, ir::{indexed::IndexedQuery, FieldValue}, schema::Schema, interpreter::execution::interpret_ir};
+
+use crate::query::SemverQuery;
+
+type QueryResultItem = BTreeMap<Arc<str>, FieldValue>;
+
+fn get_parsed_query_and_args(schema: &Schema, semver_query: &SemverQuery) -> (Arc<IndexedQuery>, Arc<QueryResultItem>) {
+    let parsed_query = parse(schema, &semver_query.query)
+        .expect("not a valid query, should have been caught in tests");
+    let args = Arc::new(
+        semver_query
+            .arguments
+            .iter()
+            .map(|(k, v)| (Arc::from(k.clone()), v.clone().into()))
+            .collect(),
+    );
+
+    (parsed_query, args)
+}
+
+pub(crate) trait Queriable<'a> {
+    fn run_query(&self, semver_query: &SemverQuery) -> anyhow::Result<Peekable<Box<dyn Iterator<Item = QueryResultItem> + 'a>>>;
+}
+
+pub(crate) struct QueriableRustdocV18<'a> {
+    schema: Schema,
+    adapter: Rc<RefCell<crate::rustdoc_v18::adapter::RustdocAdapter<'a>>>,
+}
+
+impl<'a> QueriableRustdocV18<'a> {
+    pub(crate) fn new(schema: Schema, adapter: Rc<RefCell<crate::rustdoc_v18::adapter::RustdocAdapter<'a>>>) -> Self {
+        Self {
+            schema,
+            adapter,
+        }
+    }
+}
+
+impl<'a> Queriable<'a> for QueriableRustdocV18<'a> {
+    fn run_query(&self, semver_query: &SemverQuery) -> anyhow::Result<Peekable<Box<dyn Iterator<Item = QueryResultItem> + 'a>>> {
+        let (parsed_query, args) = get_parsed_query_and_args(&self.schema, semver_query);
+
+        let results_iter = interpret_ir(self.adapter.clone(), parsed_query, args)
+            .with_context(|| "Query execution error.")?
+            .peekable();
+
+        Ok(results_iter)
+    }
+}
+
+pub(crate) struct QueriableRustdocV21<'a> {
+    schema: Schema,
+    adapter: Rc<RefCell<crate::rustdoc_v21::adapter::RustdocAdapter<'a>>>,
+}
+
+impl<'a> QueriableRustdocV21<'a> {
+    pub(crate) fn new(schema: Schema, adapter: Rc<RefCell<crate::rustdoc_v21::adapter::RustdocAdapter<'a>>>) -> Self {
+        Self {
+            schema,
+            adapter,
+        }
+    }
+}
+
+impl<'a> Queriable<'a> for QueriableRustdocV21<'a> {
+    fn run_query(&self, semver_query: &SemverQuery) -> anyhow::Result<Peekable<Box<dyn Iterator<Item = QueryResultItem> + 'a>>> {
+        let (parsed_query, args) = get_parsed_query_and_args(&self.schema, semver_query);
+
+        let results_iter = interpret_ir(self.adapter.clone(), parsed_query, args)
+            .with_context(|| "Query execution error.")?
+            .peekable();
+
+        Ok(results_iter)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,16 @@
 #![forbid(unsafe_code)]
 
-pub mod adapter;
+mod rustdoc_v18;
 mod baseline;
 mod check_release;
 mod config;
 mod dump;
-pub mod indexed_crate;
 mod manifest;
 mod query;
 mod templating;
 mod util;
+mod rustdoc_v21;
+mod execution;
 
 use std::path::PathBuf;
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -118,7 +118,7 @@ Failed to parse a query: {}
 mod tests {
     use trustfall_core::frontend::parse;
 
-    use crate::adapter::RustdocAdapter;
+    use crate::rustdoc_v18::adapter::RustdocAdapter;
 
     use super::SemverQuery;
 

--- a/src/rustdoc_v18/adapter.rs
+++ b/src/rustdoc_v18/adapter.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeSet, sync::Arc};
 
-use rustdoc_types::{
+use rustdoc_types_14::{
     Crate, Enum, Function, Id, Impl, Item, ItemEnum, Method, Path, Span, Struct, Trait, Type,
     Variant,
 };
@@ -10,7 +10,7 @@ use trustfall_core::{
     schema::Schema,
 };
 
-use crate::indexed_crate::IndexedCrate;
+use super::indexed_crate::IndexedCrate;
 
 #[non_exhaustive]
 pub struct RustdocAdapter<'a> {
@@ -30,7 +30,7 @@ impl<'a> RustdocAdapter<'a> {
     }
 
     pub fn schema() -> Schema {
-        Schema::parse(include_str!("rustdoc_schema.graphql")).expect("schema not valid")
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema not valid")
     }
 }
 
@@ -70,7 +70,7 @@ impl Origin {
         }
     }
 
-    fn make_raw_type_token<'a>(&self, raw_type: &'a rustdoc_types::Type) -> Token<'a> {
+    fn make_raw_type_token<'a>(&self, raw_type: &'a rustdoc_types_14::Type) -> Token<'a> {
         Token {
             origin: *self,
             kind: TokenKind::RawType(raw_type),
@@ -86,7 +86,7 @@ impl Origin {
 
     fn make_implemented_trait_token<'a>(
         &self,
-        path: &'a rustdoc_types::Path,
+        path: &'a rustdoc_types_14::Path,
         trait_def: &'a Item,
     ) -> Token<'a> {
         Token {
@@ -132,16 +132,16 @@ impl<'a> Token<'a> {
     fn typename(&self) -> &'static str {
         match self.kind {
             TokenKind::Item(item) => match &item.inner {
-                rustdoc_types::ItemEnum::Struct(..) => "Struct",
-                rustdoc_types::ItemEnum::Enum(..) => "Enum",
-                rustdoc_types::ItemEnum::Function(..) => "Function",
-                rustdoc_types::ItemEnum::Method(..) => "Method",
-                rustdoc_types::ItemEnum::Variant(Variant::Plain(..)) => "PlainVariant",
-                rustdoc_types::ItemEnum::Variant(Variant::Tuple(..)) => "TupleVariant",
-                rustdoc_types::ItemEnum::Variant(Variant::Struct { .. }) => "StructVariant",
-                rustdoc_types::ItemEnum::StructField(..) => "StructField",
-                rustdoc_types::ItemEnum::Impl(..) => "Impl",
-                rustdoc_types::ItemEnum::Trait(..) => "Trait",
+                rustdoc_types_14::ItemEnum::Struct(..) => "Struct",
+                rustdoc_types_14::ItemEnum::Enum(..) => "Enum",
+                rustdoc_types_14::ItemEnum::Function(..) => "Function",
+                rustdoc_types_14::ItemEnum::Method(..) => "Method",
+                rustdoc_types_14::ItemEnum::Variant(Variant::Plain) => "PlainVariant",
+                rustdoc_types_14::ItemEnum::Variant(Variant::Tuple(..)) => "TupleVariant",
+                rustdoc_types_14::ItemEnum::Variant(Variant::Struct(..)) => "StructVariant",
+                rustdoc_types_14::ItemEnum::StructField(..) => "StructField",
+                rustdoc_types_14::ItemEnum::Impl(..) => "Impl",
+                rustdoc_types_14::ItemEnum::Trait(..) => "Trait",
                 _ => unreachable!("unexpected item.inner for item: {item:?}"),
             },
             TokenKind::Span(..) => "Span",
@@ -152,8 +152,8 @@ impl<'a> Token<'a> {
             TokenKind::Attribute(..) => "Attribute",
             TokenKind::ImplementedTrait(..) => "ImplementedTrait",
             TokenKind::RawType(ty) => match ty {
-                rustdoc_types::Type::ResolvedPath { .. } => "ResolvedPathType",
-                rustdoc_types::Type::Primitive(..) => "PrimitiveType",
+                rustdoc_types_14::Type::ResolvedPath { .. } => "ResolvedPathType",
+                rustdoc_types_14::Type::Primitive(..) => "PrimitiveType",
                 _ => "OtherType",
             },
         }
@@ -186,14 +186,14 @@ impl<'a> Token<'a> {
 
     fn as_struct_item(&self) -> Option<(&'a Item, &'a Struct)> {
         self.as_item().and_then(|item| match &item.inner {
-            rustdoc_types::ItemEnum::Struct(s) => Some((item, s)),
+            rustdoc_types_14::ItemEnum::Struct(s) => Some((item, s)),
             _ => None,
         })
     }
 
     fn as_struct_field_item(&self) -> Option<(&'a Item, &'a Type)> {
         self.as_item().and_then(|item| match &item.inner {
-            rustdoc_types::ItemEnum::StructField(s) => Some((item, s)),
+            rustdoc_types_14::ItemEnum::StructField(s) => Some((item, s)),
             _ => None,
         })
     }
@@ -207,21 +207,21 @@ impl<'a> Token<'a> {
 
     fn as_enum(&self) -> Option<&'a Enum> {
         self.as_item().and_then(|item| match &item.inner {
-            rustdoc_types::ItemEnum::Enum(e) => Some(e),
+            rustdoc_types_14::ItemEnum::Enum(e) => Some(e),
             _ => None,
         })
     }
 
     fn as_trait(&self) -> Option<&'a Trait> {
         self.as_item().and_then(|item| match &item.inner {
-            rustdoc_types::ItemEnum::Trait(t) => Some(t),
+            rustdoc_types_14::ItemEnum::Trait(t) => Some(t),
             _ => None,
         })
     }
 
     fn as_variant(&self) -> Option<&'a Variant> {
         self.as_item().and_then(|item| match &item.inner {
-            rustdoc_types::ItemEnum::Variant(v) => Some(v),
+            rustdoc_types_14::ItemEnum::Variant(v) => Some(v),
             _ => None,
         })
     }
@@ -242,21 +242,21 @@ impl<'a> Token<'a> {
 
     fn as_function(&self) -> Option<&'a Function> {
         self.as_item().and_then(|item| match &item.inner {
-            rustdoc_types::ItemEnum::Function(func) => Some(func),
+            rustdoc_types_14::ItemEnum::Function(func) => Some(func),
             _ => None,
         })
     }
 
     fn as_method(&self) -> Option<&'a Method> {
         self.as_item().and_then(|item| match &item.inner {
-            rustdoc_types::ItemEnum::Method(func) => Some(func),
+            rustdoc_types_14::ItemEnum::Method(func) => Some(func),
             _ => None,
         })
     }
 
     fn as_impl(&self) -> Option<&'a Impl> {
         self.as_item().and_then(|item| match &item.inner {
-            rustdoc_types::ItemEnum::Impl(x) => Some(x),
+            rustdoc_types_14::ItemEnum::Impl(x) => Some(x),
             _ => None,
         })
     }
@@ -268,14 +268,14 @@ impl<'a> Token<'a> {
         }
     }
 
-    fn as_raw_type(&self) -> Option<&'a rustdoc_types::Type> {
+    fn as_raw_type(&self) -> Option<&'a rustdoc_types_14::Type> {
         match &self.kind {
             TokenKind::RawType(ty) => Some(*ty),
             _ => None,
         }
     }
 
-    fn as_implemented_trait(&self) -> Option<(&'a rustdoc_types::Path, &'a Item)> {
+    fn as_implemented_trait(&self) -> Option<(&'a rustdoc_types_14::Path, &'a Item)> {
         match &self.kind {
             TokenKind::ImplementedTrait(path, trait_item) => Some((*path, *trait_item)),
             _ => None,
@@ -321,10 +321,10 @@ fn get_item_property(item_token: &Token, field_name: &str) -> FieldValue {
         "docs" => (&item.docs).into(),
         "attrs" => item.attrs.clone().into(),
         "visibility_limit" => match &item.visibility {
-            rustdoc_types::Visibility::Public => "public".into(),
-            rustdoc_types::Visibility::Default => "default".into(),
-            rustdoc_types::Visibility::Crate => "crate".into(),
-            rustdoc_types::Visibility::Restricted { parent: _, path } => {
+            rustdoc_types_14::Visibility::Public => "public".into(),
+            rustdoc_types_14::Visibility::Default => "default".into(),
+            rustdoc_types_14::Visibility::Crate => "crate".into(),
+            rustdoc_types_14::Visibility::Restricted { parent: _, path } => {
                 format!("restricted ({path})").into()
             }
         },
@@ -335,18 +335,13 @@ fn get_item_property(item_token: &Token, field_name: &str) -> FieldValue {
 fn get_struct_property(item_token: &Token, field_name: &str) -> FieldValue {
     let (_, struct_item) = item_token.as_struct_item().expect("token was not a Struct");
     match field_name {
-        "struct_type" => match struct_item.kind {
-            rustdoc_types::StructKind::Plain { .. } => "plain",
-            rustdoc_types::StructKind::Tuple(..) => "tuple",
-            rustdoc_types::StructKind::Unit => "unit",
+        "struct_type" => match struct_item.struct_type {
+            rustdoc_types_14::StructType::Plain => "plain",
+            rustdoc_types_14::StructType::Tuple => "tuple",
+            rustdoc_types_14::StructType::Unit => "unit",
         }
         .into(),
-        "fields_stripped" => match struct_item.kind {
-            rustdoc_types::StructKind::Plain {
-                fields_stripped, ..
-            } => fields_stripped.into(),
-            _ => FieldValue::Null,
-        },
+        "fields_stripped" => struct_item.fields_stripped.into(),
         _ => unreachable!("Struct property {field_name}"),
     }
 }
@@ -441,8 +436,8 @@ fn get_raw_type_property(token: &Token, field_name: &str) -> FieldValue {
     let type_token = token.as_raw_type().expect("token was not a RawType");
     match field_name {
         "name" => match type_token {
-            rustdoc_types::Type::ResolvedPath(path) => (&path.name).into(),
-            rustdoc_types::Type::Primitive(name) => name.into(),
+            rustdoc_types_14::Type::ResolvedPath(path) => (&path.name).into(),
+            rustdoc_types_14::Type::Primitive(name) => name.into(),
             _ => unreachable!("unexpected RawType token content: {type_token:?}"),
         },
         _ => unreachable!("RawType property {field_name}"),
@@ -653,6 +648,27 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                                     let crate_token =
                                         token.as_indexed_crate().expect("token was not a Crate");
 
+                                    // let iter = crate_token
+                                    //     .public_items
+                                    //     .iter()
+                                    //     .copied()
+                                    //     .filter_map(|id| crate_token.inner.index.get(id))
+                                    //     .filter(|item| {
+                                    //         matches!(
+                                    //             item.inner,
+                                    //             rustdoc_types_14::ItemEnum::Struct(..)
+                                    //                 | rustdoc_types_14::ItemEnum::StructField(..)
+                                    //                 | rustdoc_types_14::ItemEnum::Enum(..)
+                                    //                 | rustdoc_types_14::ItemEnum::Variant(..)
+                                    //                 | rustdoc_types_14::ItemEnum::Function(..)
+                                    //                 | rustdoc_types_14::ItemEnum::Method(..)
+                                    //                 | rustdoc_types_14::ItemEnum::Impl(..)
+                                    //         )
+                                    //     })
+                                    //     .map(move |value| origin.make_item_token(value));
+                                    // Box::new(iter)
+                                    // TODO: temporarily only return public items for testing
+                                    //
                                     let iter = crate_token
                                         .inner
                                         .index
@@ -661,14 +677,13 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                                             // Filter out item types that are not currently supported.
                                             matches!(
                                                 item.inner,
-                                                rustdoc_types::ItemEnum::Struct(..)
-                                                    | rustdoc_types::ItemEnum::StructField(..)
-                                                    | rustdoc_types::ItemEnum::Enum(..)
-                                                    | rustdoc_types::ItemEnum::Variant(..)
-                                                    | rustdoc_types::ItemEnum::Function(..)
-                                                    | rustdoc_types::ItemEnum::Method(..)
-                                                    | rustdoc_types::ItemEnum::Impl(..)
-                                                    | rustdoc_types::ItemEnum::Trait(..)
+                                                rustdoc_types_14::ItemEnum::Struct(..)
+                                                    | rustdoc_types_14::ItemEnum::StructField(..)
+                                                    | rustdoc_types_14::ItemEnum::Enum(..)
+                                                    | rustdoc_types_14::ItemEnum::Variant(..)
+                                                    | rustdoc_types_14::ItemEnum::Function(..)
+                                                    | rustdoc_types_14::ItemEnum::Method(..)
+                                                    | rustdoc_types_14::ItemEnum::Impl(..)
                                             )
                                         })
                                         .map(move |value| origin.make_item_token(value));
@@ -839,7 +854,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                                 Box::new(impl_ids.iter().filter_map(move |item_id| {
                                     let next_item = item_index.get(item_id);
                                     next_item.and_then(|next_item| match &next_item.inner {
-                                        rustdoc_types::ItemEnum::Impl(imp) => {
+                                        rustdoc_types_14::ItemEnum::Impl(imp) => {
                                             if !inherent_impls_only || imp.trait_.is_none() {
                                                 Some(origin.make_item_token(next_item))
                                             } else {
@@ -860,45 +875,32 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                     let current_crate = self.current_crate;
                     let previous_crate = self.previous_crate;
                     Box::new(data_contexts.map(move |ctx| {
-                        let neighbors: Box<dyn Iterator<Item = Self::DataToken> + 'a> = match &ctx
-                            .current_token
-                        {
-                            None => Box::new(std::iter::empty()),
-                            Some(token) => {
-                                let origin = token.origin;
-                                let (_, struct_item) =
-                                    token.as_struct_item().expect("token was not a Struct");
+                        let neighbors: Box<dyn Iterator<Item = Self::DataToken> + 'a> =
+                            match &ctx.current_token {
+                                None => Box::new(std::iter::empty()),
+                                Some(token) => {
+                                    let origin = token.origin;
+                                    let (_, struct_item) =
+                                        token.as_struct_item().expect("token was not a Struct");
 
-                                let item_index = match origin {
-                                    Origin::CurrentCrate => &current_crate.inner.index,
-                                    Origin::PreviousCrate => {
-                                        &previous_crate
-                                            .expect("no previous crate provided")
-                                            .inner
-                                            .index
-                                    }
-                                };
-
-                                let field_ids_iter: Box<dyn Iterator<Item = &Id>> =
-                                    match &struct_item.kind {
-                                        rustdoc_types::StructKind::Unit => {
-                                            Box::new(std::iter::empty())
-                                        }
-                                        rustdoc_types::StructKind::Tuple(field_ids) => {
-                                            Box::new(field_ids.iter().filter_map(|x| x.as_ref()))
-                                        }
-                                        rustdoc_types::StructKind::Plain { fields, .. } => {
-                                            Box::new(fields.iter())
+                                    let item_index = match origin {
+                                        Origin::CurrentCrate => &current_crate.inner.index,
+                                        Origin::PreviousCrate => {
+                                            &previous_crate
+                                                .expect("no previous crate provided")
+                                                .inner
+                                                .index
                                         }
                                     };
-
-                                Box::new(field_ids_iter.map(move |field_id| {
-                                    origin.make_item_token(
-                                        item_index.get(field_id).expect("missing item"),
-                                    )
-                                }))
-                            }
-                        };
+                                    Box::new(struct_item.fields.clone().into_iter().map(
+                                        move |field_id| {
+                                            origin.make_item_token(
+                                                item_index.get(&field_id).expect("missing item"),
+                                            )
+                                        },
+                                    ))
+                                }
+                            };
 
                         (ctx, neighbors)
                     }))
@@ -1012,7 +1014,7 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
                                     let next_item = &item_index.get(item_id);
                                     if let Some(next_item) = next_item {
                                         match &next_item.inner {
-                                            rustdoc_types::ItemEnum::Method(..) => {
+                                            rustdoc_types_14::ItemEnum::Method(..) => {
                                                 Some(origin.make_item_token(next_item))
                                             }
                                             _ => None,
@@ -1141,190 +1143,4 @@ impl<'a> Adapter<'a> for RustdocAdapter<'a> {
             _ => unreachable!("can_coerce_to_type {current_type_name} {coerce_to_type_name}"),
         }
     }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::path::Path;
-    use std::{cell::RefCell, collections::BTreeMap, rc::Rc, sync::Arc};
-
-    use anyhow::Context;
-    use trustfall_core::{frontend::parse, interpreter::execution::interpret_ir, ir::FieldValue};
-
-    use crate::{indexed_crate::IndexedCrate, query::SemverQuery, util::load_rustdoc_from_file};
-
-    use super::RustdocAdapter;
-
-    #[test]
-    fn rustdoc_json_format_version() {
-        let current_crate = load_rustdoc_from_file(Path::new("./localdata/test_data/baseline.json"))
-            .with_context(|| "Could not load localdata/test_data/baseline.json file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?")
-            .expect("failed to load baseline rustdoc");
-
-        assert_eq!(current_crate.format_version, rustdoc_types::FORMAT_VERSION);
-    }
-
-    #[test]
-    fn pub_use_handling() {
-        let current_crate = load_rustdoc_from_file(Path::new("./localdata/test_data/baseline.json"))
-            .with_context(|| "Could not load localdata/test_data/baseline.json file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?")
-            .expect("failed to load baseline rustdoc");
-
-        let current = IndexedCrate::new(&current_crate);
-
-        let query = r#"
-            {
-                Crate {
-                    item {
-                        ... on Struct {
-                            name @filter(op: "=", value: ["$struct"])
-
-                            canonical_path {
-                                canonical_path: path @output
-                            }
-
-                            importable_path @fold {
-                                path @output
-                            }
-                        }
-                    }
-                }
-            }"#;
-        let mut arguments = BTreeMap::new();
-        arguments.insert("struct", "CheckPubUseHandling");
-
-        let schema = RustdocAdapter::schema();
-        let adapter = Rc::new(RefCell::new(RustdocAdapter::new(&current, None)));
-
-        let parsed_query = parse(&schema, query).unwrap();
-        let args = Arc::new(
-            arguments
-                .iter()
-                .map(|(k, v)| (Arc::from(k.to_string()), (*v).into()))
-                .collect(),
-        );
-        let results_iter = interpret_ir(adapter.clone(), parsed_query, args).unwrap();
-
-        let actual_results: Vec<BTreeMap<_, _>> = results_iter
-            .map(|res| res.into_iter().map(|(k, v)| (k.to_string(), v)).collect())
-            .collect();
-
-        let expected_result: FieldValue = vec![
-            "semver_tests",
-            "import_handling",
-            "inner",
-            "CheckPubUseHandling",
-        ]
-        .into();
-        assert_eq!(1, actual_results.len(), "{actual_results:?}");
-        assert_eq!(
-            expected_result, actual_results[0]["canonical_path"],
-            "{actual_results:?}"
-        );
-
-        let mut actual_paths = actual_results[0]["path"]
-            .as_vec(|val| val.as_vec(FieldValue::as_str))
-            .expect("not a Vec<Vec<&str>>");
-        actual_paths.sort_unstable();
-
-        let expected_paths = vec![
-            vec!["semver_tests", "CheckPubUseHandling"],
-            vec!["semver_tests", "import_handling", "CheckPubUseHandling"],
-            vec![
-                "semver_tests",
-                "import_handling",
-                "inner",
-                "CheckPubUseHandling",
-            ],
-        ];
-        assert_eq!(expected_paths, actual_paths);
-    }
-
-    fn check_query_execution(query_name: &str) {
-        // Ensure the rustdocs JSON outputs have been regenerated.
-        let baseline_crate = load_rustdoc_from_file(Path::new("./localdata/test_data/baseline.json"))
-            .with_context(|| "Could not load localdata/test_data/baseline.json file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?")
-            .expect("failed to load baseline rustdoc");
-        let current_crate =
-            load_rustdoc_from_file(Path::new(&format!("./localdata/test_data/{}.json", query_name)))
-            .with_context(|| format!("Could not load localdata/test_data/{}.json file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?", query_name))
-            .expect("failed to load rustdoc under test");
-
-        let baseline = IndexedCrate::new(&baseline_crate);
-        let current = IndexedCrate::new(&current_crate);
-
-        let query_text =
-            std::fs::read_to_string(&format!("./src/queries/{}.ron", query_name)).unwrap();
-        let semver_query: SemverQuery = ron::from_str(&query_text).unwrap();
-
-        let expected_result_text =
-            std::fs::read_to_string(&format!("./src/test_data/{}.output.ron", query_name))
-            .with_context(|| format!("Could not load src/test_data/{}.output.ron expected-outputs file, did you forget to add it?", query_name))
-            .expect("failed to load expected outputs");
-        let mut expected_results: Vec<BTreeMap<String, FieldValue>> =
-            ron::from_str(&expected_result_text)
-                .expect("could not parse expected outputs as ron format");
-
-        let schema = RustdocAdapter::schema();
-        let adapter = Rc::new(RefCell::new(RustdocAdapter::new(&current, Some(&baseline))));
-
-        let parsed_query = parse(&schema, &semver_query.query).unwrap();
-        let args = Arc::new(
-            semver_query
-                .arguments
-                .iter()
-                .map(|(k, v)| (Arc::from(k.clone()), v.clone().into()))
-                .collect(),
-        );
-        let results_iter = interpret_ir(adapter.clone(), parsed_query, args).unwrap();
-
-        let mut actual_results: Vec<BTreeMap<_, _>> = results_iter
-            .map(|res| res.into_iter().map(|(k, v)| (k.to_string(), v)).collect())
-            .collect();
-
-        // Reorder both vectors of results into a deterministic order that will compensate for
-        // nondeterminism in how the results are ordered.
-        let key_func = |elem: &BTreeMap<String, FieldValue>| {
-            (
-                elem["span_filename"].as_str().unwrap().to_owned(),
-                elem["span_begin_line"].as_usize().unwrap(),
-            )
-        };
-        expected_results.sort_unstable_by_key(key_func);
-        actual_results.sort_unstable_by_key(key_func);
-
-        assert_eq!(expected_results, actual_results);
-    }
-
-    macro_rules! query_execution_tests {
-        ($($name:ident,)*) => {
-            $(
-                #[test]
-                fn $name() {
-                    check_query_execution(stringify!($name))
-                }
-            )*
-        }
-    }
-
-    query_execution_tests!(
-        auto_trait_impl_removed,
-        derive_trait_impl_removed,
-        enum_missing,
-        enum_repr_c_removed,
-        enum_repr_int_changed,
-        enum_repr_int_removed,
-        enum_variant_added,
-        enum_variant_missing,
-        function_missing,
-        inherent_method_missing,
-        sized_impl_removed,
-        struct_marked_non_exhaustive,
-        struct_missing,
-        struct_pub_field_missing,
-        struct_repr_c_removed,
-        struct_repr_transparent_removed,
-        unit_struct_changed_kind,
-        variant_marked_non_exhaustive,
-    );
 }

--- a/src/rustdoc_v18/indexed_crate.rs
+++ b/src/rustdoc_v18/indexed_crate.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use rustdoc_types::{Crate, Id, Item, Visibility};
+use rustdoc_types_14::{Crate, Id, Item, Visibility};
 
 #[derive(Debug, Clone)]
 pub struct IndexedCrate<'a> {
@@ -41,7 +41,7 @@ impl<'a> IndexedCrate<'a> {
             stack.push(item_name);
         } else {
             assert!(
-                matches!(item.inner, rustdoc_types::ItemEnum::Import(..)),
+                matches!(item.inner, rustdoc_types_14::ItemEnum::Import(..)),
                 "{item:?}"
             );
         }
@@ -93,34 +93,28 @@ fn collect_public_items<'a>(
 
             let next_parent_id = Some(&item.id);
             match &item.inner {
-                rustdoc_types::ItemEnum::Module(m) => {
+                rustdoc_types_14::ItemEnum::Module(m) => {
                     for inner in m.items.iter().filter_map(|id| crate_.index.get(id)) {
                         collect_public_items(crate_, pub_items, inner, next_parent_id);
                     }
                 }
-                rustdoc_types::ItemEnum::Import(imp) => {
+                rustdoc_types_14::ItemEnum::Import(imp) => {
                     // TODO: handle glob imports (`pub use foo::bar::*`) here.
                     if let Some(item) = imp.id.as_ref().and_then(|id| crate_.index.get(id)) {
                         collect_public_items(crate_, pub_items, item, next_parent_id);
                     }
                 }
-                rustdoc_types::ItemEnum::Struct(struct_) => {
-                    let field_ids_iter: Box<dyn Iterator<Item = &Id>> = match &struct_.kind {
-                        rustdoc_types::StructKind::Unit => Box::new(std::iter::empty()),
-                        rustdoc_types::StructKind::Tuple(field_ids) => {
-                            Box::new(field_ids.iter().filter_map(|x| x.as_ref()))
-                        }
-                        rustdoc_types::StructKind::Plain { fields, .. } => Box::new(fields.iter()),
-                    };
-
-                    for inner in field_ids_iter
+                rustdoc_types_14::ItemEnum::Struct(struct_) => {
+                    for inner in struct_
+                        .fields
+                        .iter()
                         .chain(struct_.impls.iter())
                         .filter_map(|id| crate_.index.get(id))
                     {
                         collect_public_items(crate_, pub_items, inner, next_parent_id);
                     }
                 }
-                rustdoc_types::ItemEnum::Enum(enum_) => {
+                rustdoc_types_14::ItemEnum::Enum(enum_) => {
                     for inner in enum_
                         .variants
                         .iter()
@@ -130,12 +124,12 @@ fn collect_public_items<'a>(
                         collect_public_items(crate_, pub_items, inner, next_parent_id);
                     }
                 }
-                rustdoc_types::ItemEnum::Trait(trait_) => {
+                rustdoc_types_14::ItemEnum::Trait(trait_) => {
                     for inner in trait_.items.iter().filter_map(|id| crate_.index.get(id)) {
                         collect_public_items(crate_, pub_items, inner, next_parent_id);
                     }
                 }
-                rustdoc_types::ItemEnum::Impl(impl_) => {
+                rustdoc_types_14::ItemEnum::Impl(impl_) => {
                     for inner in impl_.items.iter().filter_map(|id| crate_.index.get(id)) {
                         collect_public_items(crate_, pub_items, inner, next_parent_id);
                     }

--- a/src/rustdoc_v18/mod.rs
+++ b/src/rustdoc_v18/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod adapter;
+pub(crate) mod indexed_crate;

--- a/src/rustdoc_v21/adapter.rs
+++ b/src/rustdoc_v21/adapter.rs
@@ -1,0 +1,1330 @@
+use std::{collections::BTreeSet, sync::Arc};
+
+use rustdoc_types_17::{
+    Crate, Enum, Function, Id, Impl, Item, ItemEnum, Method, Path, Span, Struct, Trait, Type,
+    Variant,
+};
+use trustfall_core::{
+    interpreter::{Adapter, DataContext, InterpretedQuery},
+    ir::{EdgeParameters, Eid, FieldValue, Vid},
+    schema::Schema,
+};
+
+use super::indexed_crate::IndexedCrate;
+
+#[non_exhaustive]
+pub struct RustdocAdapter<'a> {
+    current_crate: &'a IndexedCrate<'a>,
+    previous_crate: Option<&'a IndexedCrate<'a>>,
+}
+
+impl<'a> RustdocAdapter<'a> {
+    pub fn new(
+        current_crate: &'a IndexedCrate<'a>,
+        previous_crate: Option<&'a IndexedCrate<'a>>,
+    ) -> Self {
+        Self {
+            current_crate,
+            previous_crate,
+        }
+    }
+
+    pub fn schema() -> Schema {
+        Schema::parse(include_str!("../rustdoc_schema.graphql")).expect("schema not valid")
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy)]
+pub enum Origin {
+    CurrentCrate,
+    PreviousCrate,
+}
+
+impl Origin {
+    fn make_item_token<'a>(&self, item: &'a Item) -> Token<'a> {
+        Token {
+            origin: *self,
+            kind: item.into(),
+        }
+    }
+
+    fn make_span_token<'a>(&self, span: &'a Span) -> Token<'a> {
+        Token {
+            origin: *self,
+            kind: span.into(),
+        }
+    }
+
+    fn make_path_token<'a>(&self, path: &'a [String]) -> Token<'a> {
+        Token {
+            origin: *self,
+            kind: TokenKind::Path(path),
+        }
+    }
+
+    fn make_importable_path_token<'a>(&self, importable_path: Vec<&'a str>) -> Token<'a> {
+        Token {
+            origin: *self,
+            kind: TokenKind::ImportablePath(importable_path),
+        }
+    }
+
+    fn make_raw_type_token<'a>(&self, raw_type: &'a rustdoc_types_17::Type) -> Token<'a> {
+        Token {
+            origin: *self,
+            kind: TokenKind::RawType(raw_type),
+        }
+    }
+
+    fn make_attribute_token<'a>(&self, attr: &'a str) -> Token<'a> {
+        Token {
+            origin: *self,
+            kind: TokenKind::Attribute(attr),
+        }
+    }
+
+    fn make_implemented_trait_token<'a>(
+        &self,
+        path: &'a rustdoc_types_17::Path,
+        trait_def: &'a Item,
+    ) -> Token<'a> {
+        Token {
+            origin: *self,
+            kind: TokenKind::ImplementedTrait(path, trait_def),
+        }
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct Token<'a> {
+    origin: Origin,
+    kind: TokenKind<'a>,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub enum TokenKind<'a> {
+    CrateDiff((&'a IndexedCrate<'a>, &'a IndexedCrate<'a>)),
+    Crate(&'a IndexedCrate<'a>),
+    Item(&'a Item),
+    Span(&'a Span),
+    Path(&'a [String]),
+    ImportablePath(Vec<&'a str>),
+    RawType(&'a Type),
+    Attribute(&'a str),
+    ImplementedTrait(&'a Path, &'a Item),
+}
+
+#[allow(dead_code)]
+impl<'a> Token<'a> {
+    fn new_crate(origin: Origin, crate_: &'a IndexedCrate<'a>) -> Self {
+        Self {
+            origin,
+            kind: TokenKind::Crate(crate_),
+        }
+    }
+
+    /// The name of the actual runtime type of this token,
+    /// intended to fulfill resolution requests for the __typename property.
+    #[inline]
+    fn typename(&self) -> &'static str {
+        match self.kind {
+            TokenKind::Item(item) => match &item.inner {
+                rustdoc_types_17::ItemEnum::Struct(..) => "Struct",
+                rustdoc_types_17::ItemEnum::Enum(..) => "Enum",
+                rustdoc_types_17::ItemEnum::Function(..) => "Function",
+                rustdoc_types_17::ItemEnum::Method(..) => "Method",
+                rustdoc_types_17::ItemEnum::Variant(Variant::Plain(..)) => "PlainVariant",
+                rustdoc_types_17::ItemEnum::Variant(Variant::Tuple(..)) => "TupleVariant",
+                rustdoc_types_17::ItemEnum::Variant(Variant::Struct { .. }) => "StructVariant",
+                rustdoc_types_17::ItemEnum::StructField(..) => "StructField",
+                rustdoc_types_17::ItemEnum::Impl(..) => "Impl",
+                rustdoc_types_17::ItemEnum::Trait(..) => "Trait",
+                _ => unreachable!("unexpected item.inner for item: {item:?}"),
+            },
+            TokenKind::Span(..) => "Span",
+            TokenKind::Path(..) => "Path",
+            TokenKind::ImportablePath(..) => "ImportablePath",
+            TokenKind::Crate(..) => "Crate",
+            TokenKind::CrateDiff(..) => "CrateDiff",
+            TokenKind::Attribute(..) => "Attribute",
+            TokenKind::ImplementedTrait(..) => "ImplementedTrait",
+            TokenKind::RawType(ty) => match ty {
+                rustdoc_types_17::Type::ResolvedPath { .. } => "ResolvedPathType",
+                rustdoc_types_17::Type::Primitive(..) => "PrimitiveType",
+                _ => "OtherType",
+            },
+        }
+    }
+
+    fn as_crate_diff(&self) -> Option<(&'a IndexedCrate<'a>, &'a IndexedCrate<'a>)> {
+        match &self.kind {
+            TokenKind::CrateDiff(tuple) => Some(*tuple),
+            _ => None,
+        }
+    }
+
+    fn as_indexed_crate(&self) -> Option<&'a IndexedCrate<'a>> {
+        match self.kind {
+            TokenKind::Crate(c) => Some(c),
+            _ => None,
+        }
+    }
+
+    fn as_crate(&self) -> Option<&'a Crate> {
+        self.as_indexed_crate().map(|c| c.inner)
+    }
+
+    fn as_item(&self) -> Option<&'a Item> {
+        match self.kind {
+            TokenKind::Item(item) => Some(item),
+            _ => None,
+        }
+    }
+
+    fn as_struct_item(&self) -> Option<(&'a Item, &'a Struct)> {
+        self.as_item().and_then(|item| match &item.inner {
+            rustdoc_types_17::ItemEnum::Struct(s) => Some((item, s)),
+            _ => None,
+        })
+    }
+
+    fn as_struct_field_item(&self) -> Option<(&'a Item, &'a Type)> {
+        self.as_item().and_then(|item| match &item.inner {
+            rustdoc_types_17::ItemEnum::StructField(s) => Some((item, s)),
+            _ => None,
+        })
+    }
+
+    fn as_span(&self) -> Option<&'a Span> {
+        match self.kind {
+            TokenKind::Span(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    fn as_enum(&self) -> Option<&'a Enum> {
+        self.as_item().and_then(|item| match &item.inner {
+            rustdoc_types_17::ItemEnum::Enum(e) => Some(e),
+            _ => None,
+        })
+    }
+
+    fn as_trait(&self) -> Option<&'a Trait> {
+        self.as_item().and_then(|item| match &item.inner {
+            rustdoc_types_17::ItemEnum::Trait(t) => Some(t),
+            _ => None,
+        })
+    }
+
+    fn as_variant(&self) -> Option<&'a Variant> {
+        self.as_item().and_then(|item| match &item.inner {
+            rustdoc_types_17::ItemEnum::Variant(v) => Some(v),
+            _ => None,
+        })
+    }
+
+    fn as_path(&self) -> Option<&'a [String]> {
+        match &self.kind {
+            TokenKind::Path(path) => Some(*path),
+            _ => None,
+        }
+    }
+
+    fn as_importable_path(&self) -> Option<&'_ Vec<&'a str>> {
+        match &self.kind {
+            TokenKind::ImportablePath(path) => Some(path),
+            _ => None,
+        }
+    }
+
+    fn as_function(&self) -> Option<&'a Function> {
+        self.as_item().and_then(|item| match &item.inner {
+            rustdoc_types_17::ItemEnum::Function(func) => Some(func),
+            _ => None,
+        })
+    }
+
+    fn as_method(&self) -> Option<&'a Method> {
+        self.as_item().and_then(|item| match &item.inner {
+            rustdoc_types_17::ItemEnum::Method(func) => Some(func),
+            _ => None,
+        })
+    }
+
+    fn as_impl(&self) -> Option<&'a Impl> {
+        self.as_item().and_then(|item| match &item.inner {
+            rustdoc_types_17::ItemEnum::Impl(x) => Some(x),
+            _ => None,
+        })
+    }
+
+    fn as_attribute(&self) -> Option<&'a str> {
+        match &self.kind {
+            TokenKind::Attribute(attr) => Some(*attr),
+            _ => None,
+        }
+    }
+
+    fn as_raw_type(&self) -> Option<&'a rustdoc_types_17::Type> {
+        match &self.kind {
+            TokenKind::RawType(ty) => Some(*ty),
+            _ => None,
+        }
+    }
+
+    fn as_implemented_trait(&self) -> Option<(&'a rustdoc_types_17::Path, &'a Item)> {
+        match &self.kind {
+            TokenKind::ImplementedTrait(path, trait_item) => Some((*path, *trait_item)),
+            _ => None,
+        }
+    }
+}
+
+impl<'a> From<&'a Item> for TokenKind<'a> {
+    fn from(item: &'a Item) -> Self {
+        Self::Item(item)
+    }
+}
+
+impl<'a> From<&'a IndexedCrate<'a>> for TokenKind<'a> {
+    fn from(c: &'a IndexedCrate<'a>) -> Self {
+        Self::Crate(c)
+    }
+}
+
+impl<'a> From<&'a Span> for TokenKind<'a> {
+    fn from(s: &'a Span) -> Self {
+        Self::Span(s)
+    }
+}
+
+fn get_crate_property(crate_token: &Token, field_name: &str) -> FieldValue {
+    let crate_item = crate_token.as_crate().expect("token was not a Crate");
+    match field_name {
+        "root" => (&crate_item.root.0).into(),
+        "crate_version" => (&crate_item.crate_version).into(),
+        "includes_private" => crate_item.includes_private.into(),
+        "format_version" => crate_item.format_version.into(),
+        _ => unreachable!("Crate property {field_name}"),
+    }
+}
+
+fn get_item_property(item_token: &Token, field_name: &str) -> FieldValue {
+    let item = item_token.as_item().expect("token was not an Item");
+    match field_name {
+        "id" => (&item.id.0).into(),
+        "crate_id" => (&item.crate_id).into(),
+        "name" => (&item.name).into(),
+        "docs" => (&item.docs).into(),
+        "attrs" => item.attrs.clone().into(),
+        "visibility_limit" => match &item.visibility {
+            rustdoc_types_17::Visibility::Public => "public".into(),
+            rustdoc_types_17::Visibility::Default => "default".into(),
+            rustdoc_types_17::Visibility::Crate => "crate".into(),
+            rustdoc_types_17::Visibility::Restricted { parent: _, path } => {
+                format!("restricted ({path})").into()
+            }
+        },
+        _ => unreachable!("Item property {field_name}"),
+    }
+}
+
+fn get_struct_property(item_token: &Token, field_name: &str) -> FieldValue {
+    let (_, struct_item) = item_token.as_struct_item().expect("token was not a Struct");
+    match field_name {
+        "struct_type" => match struct_item.kind {
+            rustdoc_types_17::StructKind::Plain { .. } => "plain",
+            rustdoc_types_17::StructKind::Tuple(..) => "tuple",
+            rustdoc_types_17::StructKind::Unit => "unit",
+        }
+        .into(),
+        "fields_stripped" => match struct_item.kind {
+            rustdoc_types_17::StructKind::Plain {
+                fields_stripped, ..
+            } => fields_stripped.into(),
+            _ => FieldValue::Null,
+        },
+        _ => unreachable!("Struct property {field_name}"),
+    }
+}
+
+fn get_span_property(item_token: &Token, field_name: &str) -> FieldValue {
+    let span = item_token.as_span().expect("token was not a Span");
+    match field_name {
+        "filename" => span
+            .filename
+            .to_str()
+            .expect("non-representable path")
+            .into(),
+        "begin_line" => (span.begin.0 as u64).into(),
+        "begin_column" => (span.begin.1 as u64).into(),
+        "end_line" => (span.end.0 as u64).into(),
+        "end_column" => (span.end.1 as u64).into(),
+        _ => unreachable!("Span property {field_name}"),
+    }
+}
+
+fn get_enum_property(item_token: &Token, field_name: &str) -> FieldValue {
+    let enum_item = item_token.as_enum().expect("token was not an Enum");
+    match field_name {
+        "variants_stripped" => enum_item.variants_stripped.into(),
+        _ => unreachable!("Enum property {field_name}"),
+    }
+}
+
+fn get_path_property(token: &Token, field_name: &str) -> FieldValue {
+    let path_token = token.as_path().expect("token was not a Path");
+    match field_name {
+        "path" => path_token.into(),
+        _ => unreachable!("Path property {field_name}"),
+    }
+}
+
+fn get_importable_path_property(token: &Token, field_name: &str) -> FieldValue {
+    let path_token = token
+        .as_importable_path()
+        .expect("token was not an ImportablePath");
+    match field_name {
+        "path" => path_token
+            .iter()
+            .map(|x| x.to_string())
+            .collect::<Vec<_>>()
+            .into(),
+        "visibility_limit" => "public".into(),
+        _ => unreachable!("ImportablePath property {field_name}"),
+    }
+}
+
+fn get_function_like_property(token: &Token, field_name: &str) -> FieldValue {
+    let maybe_function = token.as_function();
+    let maybe_method = token.as_method();
+
+    let (header, _decl) = maybe_function
+        .map(|func| (&func.header, &func.decl))
+        .unwrap_or_else(|| {
+            let method = maybe_method.unwrap_or_else(|| {
+                unreachable!("token was neither a function nor a method: {token:?}")
+            });
+            (&method.header, &method.decl)
+        });
+
+    match field_name {
+        "const" => header.const_.into(),
+        "async" => header.async_.into(),
+        "unsafe" => header.unsafe_.into(),
+        _ => unreachable!("FunctionLike property {field_name}"),
+    }
+}
+
+fn get_impl_property(token: &Token, field_name: &str) -> FieldValue {
+    let impl_token = token.as_impl().expect("token was not an Impl");
+    match field_name {
+        "unsafe" => impl_token.is_unsafe.into(),
+        "negative" => impl_token.negative.into(),
+        "synthetic" => impl_token.synthetic.into(),
+        _ => unreachable!("Impl property {field_name}"),
+    }
+}
+
+fn get_attribute_property(token: &Token, field_name: &str) -> FieldValue {
+    let attribute_token = token.as_attribute().expect("token was not an Attribute");
+    match field_name {
+        "value" => attribute_token.into(),
+        _ => unreachable!("Attribute property {field_name}"),
+    }
+}
+
+fn get_raw_type_property(token: &Token, field_name: &str) -> FieldValue {
+    let type_token = token.as_raw_type().expect("token was not a RawType");
+    match field_name {
+        "name" => match type_token {
+            rustdoc_types_17::Type::ResolvedPath(path) => (&path.name).into(),
+            rustdoc_types_17::Type::Primitive(name) => name.into(),
+            _ => unreachable!("unexpected RawType token content: {type_token:?}"),
+        },
+        _ => unreachable!("RawType property {field_name}"),
+    }
+}
+
+fn get_implemented_trait_property(token: &Token, field_name: &str) -> FieldValue {
+    let (path, _) = token
+        .as_implemented_trait()
+        .expect("token was not a ImplementedTrait");
+    match field_name {
+        "name" => (&path.name).into(),
+        _ => unreachable!("ImplementedTrait property {field_name}"),
+    }
+}
+
+fn property_mapper<'a>(
+    ctx: DataContext<Token<'a>>,
+    field_name: &str,
+    property_getter: fn(&Token<'a>, &str) -> FieldValue,
+) -> (DataContext<Token<'a>>, FieldValue) {
+    let value = match &ctx.current_token {
+        Some(token) => property_getter(token, field_name),
+        None => FieldValue::Null,
+    };
+    (ctx, value)
+}
+
+impl<'a> Adapter<'a> for RustdocAdapter<'a> {
+    type DataToken = Token<'a>;
+
+    fn get_starting_tokens(
+        &mut self,
+        edge: Arc<str>,
+        _parameters: Option<Arc<EdgeParameters>>,
+        _query_hint: InterpretedQuery,
+        _vertex_hint: Vid,
+    ) -> Box<dyn Iterator<Item = Self::DataToken> + 'a> {
+        match edge.as_ref() {
+            "Crate" => Box::new(std::iter::once(Token::new_crate(
+                Origin::CurrentCrate,
+                self.current_crate,
+            ))),
+            "CrateDiff" => {
+                let previous_crate = self.previous_crate.expect("no previous crate provided");
+                Box::new(std::iter::once(Token {
+                    origin: Origin::CurrentCrate,
+                    kind: TokenKind::CrateDiff((self.current_crate, previous_crate)),
+                }))
+            }
+            _ => unreachable!("{edge}"),
+        }
+    }
+
+    fn project_property(
+        &mut self,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>> + 'a>,
+        current_type_name: Arc<str>,
+        field_name: Arc<str>,
+        _query_hint: InterpretedQuery,
+        _vertex_hint: Vid,
+    ) -> Box<dyn Iterator<Item = (DataContext<Self::DataToken>, FieldValue)> + 'a> {
+        if field_name.as_ref() == "__typename" {
+            Box::new(data_contexts.map(|ctx| match &ctx.current_token {
+                Some(token) => {
+                    let value = token.typename().into();
+                    (ctx, value)
+                }
+                None => (ctx, FieldValue::Null),
+            }))
+        } else {
+            match current_type_name.as_ref() {
+                "Crate" => {
+                    Box::new(data_contexts.map(move |ctx| {
+                        property_mapper(ctx, field_name.as_ref(), get_crate_property)
+                    }))
+                }
+                "Item" => {
+                    Box::new(data_contexts.map(move |ctx| {
+                        property_mapper(ctx, field_name.as_ref(), get_item_property)
+                    }))
+                }
+                "ImplOwner" | "Struct" | "StructField" | "Enum" | "Variant" | "PlainVariant"
+                | "TupleVariant" | "StructVariant" | "Trait" | "Function" | "Method" | "Impl"
+                    if matches!(
+                        field_name.as_ref(),
+                        "id" | "crate_id" | "name" | "docs" | "attrs" | "visibility_limit"
+                    ) =>
+                {
+                    // properties inherited from Item, accesssed on Item subtypes
+                    Box::new(data_contexts.map(move |ctx| {
+                        property_mapper(ctx, field_name.as_ref(), get_item_property)
+                    }))
+                }
+                "Struct" => Box::new(data_contexts.map(move |ctx| {
+                    property_mapper(ctx, field_name.as_ref(), get_struct_property)
+                })),
+                "Enum" => {
+                    Box::new(data_contexts.map(move |ctx| {
+                        property_mapper(ctx, field_name.as_ref(), get_enum_property)
+                    }))
+                }
+                "Span" => {
+                    Box::new(data_contexts.map(move |ctx| {
+                        property_mapper(ctx, field_name.as_ref(), get_span_property)
+                    }))
+                }
+                "Path" => {
+                    Box::new(data_contexts.map(move |ctx| {
+                        property_mapper(ctx, field_name.as_ref(), get_path_property)
+                    }))
+                }
+                "ImportablePath" => Box::new(data_contexts.map(move |ctx| {
+                    property_mapper(ctx, field_name.as_ref(), get_importable_path_property)
+                })),
+                "FunctionLike" | "Function" | "Method"
+                    if matches!(field_name.as_ref(), "const" | "unsafe" | "async") =>
+                {
+                    Box::new(data_contexts.map(move |ctx| {
+                        property_mapper(ctx, field_name.as_ref(), get_function_like_property)
+                    }))
+                }
+                "Impl" => {
+                    Box::new(data_contexts.map(move |ctx| {
+                        property_mapper(ctx, field_name.as_ref(), get_impl_property)
+                    }))
+                }
+                "Attribute" => Box::new(data_contexts.map(move |ctx| {
+                    property_mapper(ctx, field_name.as_ref(), get_attribute_property)
+                })),
+                "ImplementedTrait" => Box::new(data_contexts.map(move |ctx| {
+                    property_mapper(ctx, field_name.as_ref(), get_implemented_trait_property)
+                })),
+                "RawType" | "ResolvedPathType" | "PrimitiveType"
+                    if matches!(field_name.as_ref(), "name") =>
+                {
+                    Box::new(data_contexts.map(move |ctx| {
+                        // fields from "RawType"
+                        property_mapper(ctx, field_name.as_ref(), get_raw_type_property)
+                    }))
+                }
+                _ => unreachable!("project_property {current_type_name} {field_name}"),
+            }
+        }
+    }
+
+    fn project_neighbors(
+        &mut self,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>> + 'a>,
+        current_type_name: Arc<str>,
+        edge_name: Arc<str>,
+        parameters: Option<Arc<EdgeParameters>>,
+        _query_hint: InterpretedQuery,
+        _vertex_hint: Vid,
+        _edge_hint: Eid,
+    ) -> Box<
+        dyn Iterator<
+                Item = (
+                    DataContext<Self::DataToken>,
+                    Box<dyn Iterator<Item = Self::DataToken> + 'a>,
+                ),
+            > + 'a,
+    > {
+        match current_type_name.as_ref() {
+            "CrateDiff" => match edge_name.as_ref() {
+                "current" => Box::new(data_contexts.map(move |ctx| {
+                    let neighbors: Box<dyn Iterator<Item = Self::DataToken> + 'a> = match &ctx
+                        .current_token
+                    {
+                        None => Box::new(std::iter::empty()),
+                        Some(token) => {
+                            let crate_tuple =
+                                token.as_crate_diff().expect("token was not a CrateDiff");
+                            let neighbor = Token::new_crate(Origin::CurrentCrate, crate_tuple.0);
+                            Box::new(std::iter::once(neighbor))
+                        }
+                    };
+
+                    (ctx, neighbors)
+                })),
+                "baseline" => Box::new(data_contexts.map(move |ctx| {
+                    let neighbors: Box<dyn Iterator<Item = Self::DataToken> + 'a> = match &ctx
+                        .current_token
+                    {
+                        None => Box::new(std::iter::empty()),
+                        Some(token) => {
+                            let crate_tuple =
+                                token.as_crate_diff().expect("token was not a CrateDiff");
+                            let neighbor = Token::new_crate(Origin::PreviousCrate, crate_tuple.1);
+                            Box::new(std::iter::once(neighbor))
+                        }
+                    };
+
+                    (ctx, neighbors)
+                })),
+                _ => {
+                    unreachable!("project_neighbors {current_type_name} {edge_name} {parameters:?}")
+                }
+            },
+            "Crate" => {
+                match edge_name.as_ref() {
+                    "item" => Box::new(data_contexts.map(move |ctx| {
+                        let neighbors: Box<dyn Iterator<Item = Self::DataToken> + 'a> =
+                            match &ctx.current_token {
+                                None => Box::new(std::iter::empty()),
+                                Some(token) => {
+                                    let origin = token.origin;
+                                    let crate_token =
+                                        token.as_indexed_crate().expect("token was not a Crate");
+
+                                    let iter = crate_token
+                                        .inner
+                                        .index
+                                        .values()
+                                        .filter(|item| {
+                                            // Filter out item types that are not currently supported.
+                                            matches!(
+                                                item.inner,
+                                                rustdoc_types_17::ItemEnum::Struct(..)
+                                                    | rustdoc_types_17::ItemEnum::StructField(..)
+                                                    | rustdoc_types_17::ItemEnum::Enum(..)
+                                                    | rustdoc_types_17::ItemEnum::Variant(..)
+                                                    | rustdoc_types_17::ItemEnum::Function(..)
+                                                    | rustdoc_types_17::ItemEnum::Method(..)
+                                                    | rustdoc_types_17::ItemEnum::Impl(..)
+                                                    | rustdoc_types_17::ItemEnum::Trait(..)
+                                            )
+                                        })
+                                        .map(move |value| origin.make_item_token(value));
+                                    Box::new(iter)
+                                }
+                            };
+
+                        (ctx, neighbors)
+                    })),
+                    _ => unreachable!(
+                        "project_neighbors {current_type_name} {edge_name} {parameters:?}"
+                    ),
+                }
+            }
+            "Importable" | "ImplOwner" | "Struct" | "Enum" | "Trait" | "Function"
+                if matches!(edge_name.as_ref(), "importable_path" | "canonical_path") =>
+            {
+                match edge_name.as_ref() {
+                    "canonical_path" => {
+                        let current_crate = self.current_crate;
+                        let previous_crate = self.previous_crate;
+
+                        Box::new(data_contexts.map(move |ctx| {
+                            let neighbors: Box<dyn Iterator<Item = Self::DataToken> + 'a> =
+                                match &ctx.current_token {
+                                    None => Box::new(std::iter::empty()),
+                                    Some(token) => {
+                                        let origin = token.origin;
+                                        let item = token.as_item().expect("token was not an Item");
+                                        let item_id = &item.id;
+
+                                        if let Some(path) = match origin {
+                                            Origin::CurrentCrate => current_crate
+                                                .inner
+                                                .paths
+                                                .get(item_id)
+                                                .map(|x| &x.path),
+                                            Origin::PreviousCrate => previous_crate
+                                                .expect("no baseline provided")
+                                                .inner
+                                                .paths
+                                                .get(item_id)
+                                                .map(|x| &x.path),
+                                        } {
+                                            Box::new(std::iter::once(origin.make_path_token(path)))
+                                        } else {
+                                            Box::new(std::iter::empty())
+                                        }
+                                    }
+                                };
+
+                            (ctx, neighbors)
+                        }))
+                    }
+                    "importable_path" => {
+                        let current_crate = self.current_crate;
+                        let previous_crate = self.previous_crate;
+
+                        Box::new(data_contexts.map(move |ctx| {
+                            let neighbors: Box<dyn Iterator<Item = Self::DataToken> + 'a> =
+                                match &ctx.current_token {
+                                    None => Box::new(std::iter::empty()),
+                                    Some(token) => {
+                                        let origin = token.origin;
+                                        let item = token.as_item().expect("token was not an Item");
+                                        let item_id = &item.id;
+
+                                        let parent_crate = match origin {
+                                            Origin::CurrentCrate => current_crate,
+                                            Origin::PreviousCrate => {
+                                                previous_crate.expect("no baseline provided")
+                                            }
+                                        };
+
+                                        Box::new(
+                                            parent_crate
+                                                .publicly_importable_names(item_id)
+                                                .into_iter()
+                                                .map(move |x| origin.make_importable_path_token(x)),
+                                        )
+                                    }
+                                };
+
+                            (ctx, neighbors)
+                        }))
+                    }
+                    _ => unreachable!(
+                        "project_neighbors {current_type_name} {edge_name} {parameters:?}"
+                    ),
+                }
+            }
+            "Item" | "ImplOwner" | "Struct" | "StructField" | "Enum" | "Variant"
+            | "PlainVariant" | "TupleVariant" | "StructVariant" | "Trait" | "Function"
+            | "Method" | "Impl"
+                if matches!(edge_name.as_ref(), "span" | "attribute") =>
+            {
+                match edge_name.as_ref() {
+                    "span" => Box::new(data_contexts.map(move |ctx| {
+                        let neighbors: Box<dyn Iterator<Item = Self::DataToken> + 'a> =
+                            match &ctx.current_token {
+                                None => Box::new(std::iter::empty()),
+                                Some(token) => {
+                                    let origin = token.origin;
+                                    let item = token.as_item().expect("token was not an Item");
+                                    if let Some(span) = &item.span {
+                                        Box::new(std::iter::once(origin.make_span_token(span)))
+                                    } else {
+                                        Box::new(std::iter::empty())
+                                    }
+                                }
+                            };
+
+                        (ctx, neighbors)
+                    })),
+                    "attribute" => Box::new(data_contexts.map(move |ctx| {
+                        let neighbors: Box<dyn Iterator<Item = Self::DataToken> + 'a> =
+                            match &ctx.current_token {
+                                None => Box::new(std::iter::empty()),
+                                Some(token) => {
+                                    let origin = token.origin;
+                                    let item = token.as_item().expect("token was not an Item");
+                                    Box::new(
+                                        item.attrs
+                                            .iter()
+                                            .map(move |attr| origin.make_attribute_token(attr)),
+                                    )
+                                }
+                            };
+
+                        (ctx, neighbors)
+                    })),
+                    _ => unreachable!(
+                        "project_neighbors {current_type_name} {edge_name} {parameters:?}"
+                    ),
+                }
+            }
+            "ImplOwner" | "Struct" | "Enum"
+                if matches!(edge_name.as_ref(), "impl" | "inherent_impl") =>
+            {
+                let current_crate = self.current_crate;
+                let previous_crate = self.previous_crate;
+                let inherent_impls_only = edge_name.as_ref() == "inherent_impl";
+                Box::new(data_contexts.map(move |ctx| {
+                    let neighbors: Box<dyn Iterator<Item = Self::DataToken> + 'a> =
+                        match &ctx.current_token {
+                            None => Box::new(std::iter::empty()),
+                            Some(token) => {
+                                let origin = token.origin;
+                                let item_index = match origin {
+                                    Origin::CurrentCrate => &current_crate.inner.index,
+                                    Origin::PreviousCrate => {
+                                        &previous_crate
+                                            .expect("no previous crate provided")
+                                            .inner
+                                            .index
+                                    }
+                                };
+
+                                // Get the IDs of all the impl blocks.
+                                // Relies on the fact that only structs and enums can have impls,
+                                // so we know that the token must represent either a struct or an enum.
+                                let impl_ids = token
+                                    .as_struct_item()
+                                    .map(|(_, s)| &s.impls)
+                                    .or_else(|| token.as_enum().map(|e| &e.impls))
+                                    .expect("token was neither a struct nor an enum");
+
+                                Box::new(impl_ids.iter().filter_map(move |item_id| {
+                                    let next_item = item_index.get(item_id);
+                                    next_item.and_then(|next_item| match &next_item.inner {
+                                        rustdoc_types_17::ItemEnum::Impl(imp) => {
+                                            if !inherent_impls_only || imp.trait_.is_none() {
+                                                Some(origin.make_item_token(next_item))
+                                            } else {
+                                                None
+                                            }
+                                        }
+                                        _ => None,
+                                    })
+                                }))
+                            }
+                        };
+
+                    (ctx, neighbors)
+                }))
+            }
+            "Struct" => match edge_name.as_ref() {
+                "field" => {
+                    let current_crate = self.current_crate;
+                    let previous_crate = self.previous_crate;
+                    Box::new(data_contexts.map(move |ctx| {
+                        let neighbors: Box<dyn Iterator<Item = Self::DataToken> + 'a> = match &ctx
+                            .current_token
+                        {
+                            None => Box::new(std::iter::empty()),
+                            Some(token) => {
+                                let origin = token.origin;
+                                let (_, struct_item) =
+                                    token.as_struct_item().expect("token was not a Struct");
+
+                                let item_index = match origin {
+                                    Origin::CurrentCrate => &current_crate.inner.index,
+                                    Origin::PreviousCrate => {
+                                        &previous_crate
+                                            .expect("no previous crate provided")
+                                            .inner
+                                            .index
+                                    }
+                                };
+
+                                let field_ids_iter: Box<dyn Iterator<Item = &Id>> =
+                                    match &struct_item.kind {
+                                        rustdoc_types_17::StructKind::Unit => {
+                                            Box::new(std::iter::empty())
+                                        }
+                                        rustdoc_types_17::StructKind::Tuple(field_ids) => {
+                                            Box::new(field_ids.iter().filter_map(|x| x.as_ref()))
+                                        }
+                                        rustdoc_types_17::StructKind::Plain { fields, .. } => {
+                                            Box::new(fields.iter())
+                                        }
+                                    };
+
+                                Box::new(field_ids_iter.map(move |field_id| {
+                                    origin.make_item_token(
+                                        item_index.get(field_id).expect("missing item"),
+                                    )
+                                }))
+                            }
+                        };
+
+                        (ctx, neighbors)
+                    }))
+                }
+                _ => {
+                    unreachable!("project_neighbors {current_type_name} {edge_name} {parameters:?}")
+                }
+            },
+            "Enum" => match edge_name.as_ref() {
+                "variant" => {
+                    let current_crate = self.current_crate;
+                    let previous_crate = self.previous_crate;
+                    Box::new(data_contexts.map(move |ctx| {
+                        let neighbors: Box<dyn Iterator<Item = Self::DataToken> + 'a> =
+                            match &ctx.current_token {
+                                None => Box::new(std::iter::empty()),
+                                Some(token) => {
+                                    let origin = token.origin;
+                                    let enum_item = token.as_enum().expect("token was not a Enum");
+
+                                    let item_index = match origin {
+                                        Origin::CurrentCrate => &current_crate.inner.index,
+                                        Origin::PreviousCrate => {
+                                            &previous_crate
+                                                .expect("no previous crate provided")
+                                                .inner
+                                                .index
+                                        }
+                                    };
+                                    Box::new(enum_item.variants.iter().map(move |field_id| {
+                                        origin.make_item_token(
+                                            item_index.get(field_id).expect("missing item"),
+                                        )
+                                    }))
+                                }
+                            };
+
+                        (ctx, neighbors)
+                    }))
+                }
+                _ => {
+                    unreachable!("project_neighbors {current_type_name} {edge_name} {parameters:?}")
+                }
+            },
+            "StructField" => match edge_name.as_ref() {
+                "raw_type" => Box::new(data_contexts.map(move |ctx| {
+                    let neighbors: Box<dyn Iterator<Item = Self::DataToken> + 'a> =
+                        match &ctx.current_token {
+                            None => Box::new(std::iter::empty()),
+                            Some(token) => {
+                                let origin = token.origin;
+                                let (_, field_type) = token
+                                    .as_struct_field_item()
+                                    .expect("not a StructField token");
+                                Box::new(std::iter::once(origin.make_raw_type_token(field_type)))
+                            }
+                        };
+
+                    (ctx, neighbors)
+                })),
+                _ => {
+                    unreachable!("project_neighbors {current_type_name} {edge_name} {parameters:?}")
+                }
+            },
+            "Impl" => {
+                match edge_name.as_ref() {
+                    "method" => {
+                        let current_crate = self.current_crate;
+                        let previous_crate = self.previous_crate;
+                        Box::new(data_contexts.map(move |ctx| {
+                        let neighbors: Box<dyn Iterator<Item = Self::DataToken> + 'a> = match &ctx
+                            .current_token
+                        {
+                            None => Box::new(std::iter::empty()),
+                            Some(token) => {
+                                let origin = token.origin;
+                                let item_index = match origin {
+                                    Origin::CurrentCrate => &current_crate.inner.index,
+                                    Origin::PreviousCrate => {
+                                        &previous_crate.expect("no previous crate provided").inner.index
+                                    }
+                                };
+
+                                let impl_token = token.as_impl().expect("not an Impl token");
+                                let provided_methods: Box<dyn Iterator<Item = &Id>> = if impl_token.provided_trait_methods.is_empty() {
+                                    Box::new(std::iter::empty())
+                                } else {
+                                    let method_names: BTreeSet<&str> = impl_token.provided_trait_methods.iter().map(|x| x.as_str()).collect();
+
+                                    let trait_path = impl_token.trait_.as_ref().expect("no trait but provided_trait_methods was non-empty");
+                                    let trait_item = item_index.get(&trait_path.id);
+
+                                    if let Some(trait_item) = trait_item {
+                                        if let ItemEnum::Trait(trait_item) = &trait_item.inner {
+                                            Box::new(trait_item.items.iter().filter(move |item_id| {
+                                                let next_item = &item_index.get(item_id);
+                                                if let Some(name) = next_item.and_then(|x| x.name.as_deref()) {
+                                                    method_names.contains(name)
+                                                } else {
+                                                    false
+                                                }
+                                            }))
+                                        } else {
+                                            unreachable!("found a non-trait type {trait_item:?}");
+                                        }
+                                    } else {
+                                        Box::new(std::iter::empty())
+                                    }
+                                };
+                                Box::new(provided_methods.chain(impl_token.items.iter()).filter_map(move |item_id| {
+                                    let next_item = &item_index.get(item_id);
+                                    if let Some(next_item) = next_item {
+                                        match &next_item.inner {
+                                            rustdoc_types_17::ItemEnum::Method(..) => {
+                                                Some(origin.make_item_token(next_item))
+                                            }
+                                            _ => None,
+                                        }
+                                    } else {
+                                        None
+                                    }
+                                }))
+                            }
+                        };
+
+                        (ctx, neighbors)
+                    }))
+                    }
+                    "implemented_trait" => {
+                        let current_crate = self.current_crate;
+                        let previous_crate = self.previous_crate;
+                        Box::new(data_contexts.map(move |ctx| {
+                            let neighbors: Box<dyn Iterator<Item = Self::DataToken> + 'a> =
+                                match &ctx.current_token {
+                                    None => Box::new(std::iter::empty()),
+                                    Some(token) => {
+                                        let origin = token.origin;
+                                        let item_index = match origin {
+                                            Origin::CurrentCrate => &current_crate.inner.index,
+                                            Origin::PreviousCrate => {
+                                                &previous_crate
+                                                    .expect("no previous crate provided")
+                                                    .inner
+                                                    .index
+                                            }
+                                        };
+
+                                        let impl_token =
+                                            token.as_impl().expect("not an Impl token");
+
+                                        if let Some(path) = &impl_token.trait_ {
+                                            if let Some(item) = item_index.get(&path.id) {
+                                                Box::new(std::iter::once(
+                                                    origin.make_implemented_trait_token(path, item),
+                                                ))
+                                            } else {
+                                                Box::new(std::iter::empty())
+                                            }
+                                        } else {
+                                            Box::new(std::iter::empty())
+                                        }
+                                    }
+                                };
+
+                            (ctx, neighbors)
+                        }))
+                    }
+                    _ => {
+                        unreachable!(
+                            "project_neighbors {current_type_name} {edge_name} {parameters:?}"
+                        )
+                    }
+                }
+            }
+            "ImplementedTrait" => match edge_name.as_ref() {
+                "trait" => Box::new(data_contexts.map(move |ctx| {
+                    let neighbors: Box<dyn Iterator<Item = Self::DataToken> + 'a> =
+                        match &ctx.current_token {
+                            None => Box::new(std::iter::empty()),
+                            Some(token) => {
+                                let origin = token.origin;
+
+                                let (_, trait_item) = token
+                                    .as_implemented_trait()
+                                    .expect("token was not an ImplementedTrait");
+                                Box::new(std::iter::once(origin.make_item_token(trait_item)))
+                            }
+                        };
+
+                    (ctx, neighbors)
+                })),
+                _ => {
+                    unreachable!("project_neighbors {current_type_name} {edge_name} {parameters:?}")
+                }
+            },
+            _ => unreachable!("project_neighbors {current_type_name} {edge_name} {parameters:?}"),
+        }
+    }
+
+    fn can_coerce_to_type(
+        &mut self,
+        data_contexts: Box<dyn Iterator<Item = DataContext<Self::DataToken>> + 'a>,
+        current_type_name: Arc<str>,
+        coerce_to_type_name: Arc<str>,
+        _query_hint: InterpretedQuery,
+        _vertex_hint: Vid,
+    ) -> Box<dyn Iterator<Item = (DataContext<Self::DataToken>, bool)> + 'a> {
+        match current_type_name.as_ref() {
+            "Item" | "Variant" | "FunctionLike" | "Importable" | "ImplOwner" | "RawType"
+            | "ResolvedPathType" => {
+                Box::new(data_contexts.map(move |ctx| {
+                    let can_coerce = match &ctx.current_token {
+                        None => false,
+                        Some(token) => {
+                            let actual_type_name = token.typename();
+
+                            match coerce_to_type_name.as_ref() {
+                                "Variant" => matches!(
+                                    actual_type_name,
+                                    "PlainVariant" | "TupleVariant" | "StructVariant"
+                                ),
+                                "ImplOwner" => matches!(actual_type_name, "Struct" | "Enum"),
+                                "ResolvedPathType" => matches!(
+                                    actual_type_name,
+                                    "ResolvedPathType" | "ImplementedTrait"
+                                ),
+                                _ => {
+                                    // The remaining types are final (don't have any subtypes)
+                                    // so we can just compare the actual type name to
+                                    // the type we are attempting to coerce to.
+                                    actual_type_name == coerce_to_type_name.as_ref()
+                                }
+                            }
+                        }
+                    };
+
+                    (ctx, can_coerce)
+                }))
+            }
+            _ => unreachable!("can_coerce_to_type {current_type_name} {coerce_to_type_name}"),
+        }
+    }
+}
+
+// #[cfg(test)]
+// mod tests {
+//     use std::path::Path;
+//     use std::{cell::RefCell, collections::BTreeMap, rc::Rc, sync::Arc};
+
+//     use anyhow::Context;
+//     use trustfall_core::{frontend::parse, interpreter::execution::interpret_ir, ir::FieldValue};
+
+//     use crate::{indexed_crate::IndexedCrate, query::SemverQuery, util::load_rustdoc_from_file};
+
+//     use super::RustdocAdapter;
+
+//     #[test]
+//     fn rustdoc_json_format_version() {
+//         let current_crate = load_rustdoc_from_file(Path::new("./localdata/test_data/baseline.json"))
+//             .with_context(|| "Could not load localdata/test_data/baseline.json file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?")
+//             .expect("failed to load baseline rustdoc");
+
+//         assert_eq!(current_crate.format_version, rustdoc_types_17::FORMAT_VERSION);
+//     }
+
+//     #[test]
+//     fn pub_use_handling() {
+//         let current_crate = load_rustdoc_from_file(Path::new("./localdata/test_data/baseline.json"))
+//             .with_context(|| "Could not load localdata/test_data/baseline.json file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?")
+//             .expect("failed to load baseline rustdoc");
+
+//         let current = IndexedCrate::new(&current_crate);
+
+//         let query = r#"
+//             {
+//                 Crate {
+//                     item {
+//                         ... on Struct {
+//                             name @filter(op: "=", value: ["$struct"])
+
+//                             canonical_path {
+//                                 canonical_path: path @output
+//                             }
+
+//                             importable_path @fold {
+//                                 path @output
+//                             }
+//                         }
+//                     }
+//                 }
+//             }"#;
+//         let mut arguments = BTreeMap::new();
+//         arguments.insert("struct", "CheckPubUseHandling");
+
+//         let schema = RustdocAdapter::schema();
+//         let adapter = Rc::new(RefCell::new(RustdocAdapter::new(&current, None)));
+
+//         let parsed_query = parse(&schema, query).unwrap();
+//         let args = Arc::new(
+//             arguments
+//                 .iter()
+//                 .map(|(k, v)| (Arc::from(k.to_string()), (*v).into()))
+//                 .collect(),
+//         );
+//         let results_iter = interpret_ir(adapter.clone(), parsed_query, args).unwrap();
+
+//         let actual_results: Vec<BTreeMap<_, _>> = results_iter
+//             .map(|res| res.into_iter().map(|(k, v)| (k.to_string(), v)).collect())
+//             .collect();
+
+//         let expected_result: FieldValue = vec![
+//             "semver_tests",
+//             "import_handling",
+//             "inner",
+//             "CheckPubUseHandling",
+//         ]
+//         .into();
+//         assert_eq!(1, actual_results.len(), "{actual_results:?}");
+//         assert_eq!(
+//             expected_result, actual_results[0]["canonical_path"],
+//             "{actual_results:?}"
+//         );
+
+//         let mut actual_paths = actual_results[0]["path"]
+//             .as_vec(|val| val.as_vec(FieldValue::as_str))
+//             .expect("not a Vec<Vec<&str>>");
+//         actual_paths.sort_unstable();
+
+//         let expected_paths = vec![
+//             vec!["semver_tests", "CheckPubUseHandling"],
+//             vec!["semver_tests", "import_handling", "CheckPubUseHandling"],
+//             vec![
+//                 "semver_tests",
+//                 "import_handling",
+//                 "inner",
+//                 "CheckPubUseHandling",
+//             ],
+//         ];
+//         assert_eq!(expected_paths, actual_paths);
+//     }
+
+//     fn check_query_execution(query_name: &str) {
+//         // Ensure the rustdocs JSON outputs have been regenerated.
+//         let baseline_crate = load_rustdoc_from_file(Path::new("./localdata/test_data/baseline.json"))
+//             .with_context(|| "Could not load localdata/test_data/baseline.json file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?")
+//             .expect("failed to load baseline rustdoc");
+//         let current_crate =
+//             load_rustdoc_from_file(Path::new(&format!("./localdata/test_data/{}.json", query_name)))
+//             .with_context(|| format!("Could not load localdata/test_data/{}.json file, did you forget to run ./scripts/regenerate_test_rustdocs.sh ?", query_name))
+//             .expect("failed to load rustdoc under test");
+
+//         let baseline = IndexedCrate::new(&baseline_crate);
+//         let current = IndexedCrate::new(&current_crate);
+
+//         let query_text =
+//             std::fs::read_to_string(&format!("./src/queries/{}.ron", query_name)).unwrap();
+//         let semver_query: SemverQuery = ron::from_str(&query_text).unwrap();
+
+//         let expected_result_text =
+//             std::fs::read_to_string(&format!("./src/test_data/{}.output.ron", query_name))
+//             .with_context(|| format!("Could not load src/test_data/{}.output.ron expected-outputs file, did you forget to add it?", query_name))
+//             .expect("failed to load expected outputs");
+//         let mut expected_results: Vec<BTreeMap<String, FieldValue>> =
+//             ron::from_str(&expected_result_text)
+//                 .expect("could not parse expected outputs as ron format");
+
+//         let schema = RustdocAdapter::schema();
+//         let adapter = Rc::new(RefCell::new(RustdocAdapter::new(&current, Some(&baseline))));
+
+//         let parsed_query = parse(&schema, &semver_query.query).unwrap();
+//         let args = Arc::new(
+//             semver_query
+//                 .arguments
+//                 .iter()
+//                 .map(|(k, v)| (Arc::from(k.clone()), v.clone().into()))
+//                 .collect(),
+//         );
+//         let results_iter = interpret_ir(adapter.clone(), parsed_query, args).unwrap();
+
+//         let mut actual_results: Vec<BTreeMap<_, _>> = results_iter
+//             .map(|res| res.into_iter().map(|(k, v)| (k.to_string(), v)).collect())
+//             .collect();
+
+//         // Reorder both vectors of results into a deterministic order that will compensate for
+//         // nondeterminism in how the results are ordered.
+//         let key_func = |elem: &BTreeMap<String, FieldValue>| {
+//             (
+//                 elem["span_filename"].as_str().unwrap().to_owned(),
+//                 elem["span_begin_line"].as_usize().unwrap(),
+//             )
+//         };
+//         expected_results.sort_unstable_by_key(key_func);
+//         actual_results.sort_unstable_by_key(key_func);
+
+//         assert_eq!(expected_results, actual_results);
+//     }
+
+//     macro_rules! query_execution_tests {
+//         ($($name:ident,)*) => {
+//             $(
+//                 #[test]
+//                 fn $name() {
+//                     check_query_execution(stringify!($name))
+//                 }
+//             )*
+//         }
+//     }
+
+//     query_execution_tests!(
+//         auto_trait_impl_removed,
+//         derive_trait_impl_removed,
+//         enum_missing,
+//         enum_repr_c_removed,
+//         enum_repr_int_changed,
+//         enum_repr_int_removed,
+//         enum_variant_added,
+//         enum_variant_missing,
+//         function_missing,
+//         inherent_method_missing,
+//         sized_impl_removed,
+//         struct_marked_non_exhaustive,
+//         struct_missing,
+//         struct_pub_field_missing,
+//         struct_repr_c_removed,
+//         struct_repr_transparent_removed,
+//         unit_struct_changed_kind,
+//         variant_marked_non_exhaustive,
+//     );
+// }

--- a/src/rustdoc_v21/indexed_crate.rs
+++ b/src/rustdoc_v21/indexed_crate.rs
@@ -1,0 +1,150 @@
+use std::collections::HashMap;
+
+use rustdoc_types_17::{Crate, Id, Item, Visibility};
+
+#[derive(Debug, Clone)]
+pub struct IndexedCrate<'a> {
+    pub(crate) inner: &'a Crate,
+
+    // For an Id, give the list of item Ids under which it is publicly visible.
+    pub(crate) visibility_forest: HashMap<&'a Id, Vec<&'a Id>>,
+}
+
+impl<'a> IndexedCrate<'a> {
+    pub fn new(crate_: &'a Crate) -> Self {
+        let visibility_forest = calculate_visibility_forest(crate_);
+
+        Self {
+            inner: crate_,
+            visibility_forest,
+        }
+    }
+
+    pub fn publicly_importable_names(&self, id: &'a Id) -> Vec<Vec<&'a str>> {
+        let mut result = vec![];
+
+        if self.inner.index.contains_key(id) {
+            self.collect_publicly_importable_names(id, &mut vec![], &mut result);
+        }
+
+        result
+    }
+
+    fn collect_publicly_importable_names(
+        &self,
+        next_id: &'a Id,
+        stack: &mut Vec<&'a str>,
+        output: &mut Vec<Vec<&'a str>>,
+    ) {
+        let item = &self.inner.index[next_id];
+        if let Some(item_name) = item.name.as_deref() {
+            stack.push(item_name);
+        } else {
+            assert!(
+                matches!(item.inner, rustdoc_types_17::ItemEnum::Import(..)),
+                "{item:?}"
+            );
+        }
+
+        if next_id == &self.inner.root {
+            let final_name = stack.iter().rev().copied().collect();
+            output.push(final_name);
+        } else if let Some(visible_parents) = self.visibility_forest.get(next_id) {
+            for parent_id in visible_parents.iter().copied() {
+                self.collect_publicly_importable_names(parent_id, stack, output);
+            }
+        }
+
+        if let Some(item_name) = item.name.as_deref() {
+            let popped_item = stack.pop().expect("stack was unexpectedly empty");
+            assert_eq!(item_name, popped_item);
+        }
+    }
+}
+
+fn calculate_visibility_forest(crate_: &Crate) -> HashMap<&Id, Vec<&Id>> {
+    let mut result = Default::default();
+    let root_id = &crate_.root;
+    if let Some(root_module) = crate_.index.get(root_id) {
+        if root_module.visibility == Visibility::Public {
+            collect_public_items(crate_, &mut result, root_module, None);
+        }
+    }
+
+    result
+}
+
+fn collect_public_items<'a>(
+    crate_: &'a Crate,
+    pub_items: &mut HashMap<&'a Id, Vec<&'a Id>>,
+    item: &'a Item,
+    parent_id: Option<&'a Id>,
+) {
+    match item.visibility {
+        // Some impls and methods have default visibility:
+        // they are visible only if the type to which they belong is visible.
+        // However, we don't recurse into non-public items with this function, so
+        // reachable items with default visibility must be public.
+        Visibility::Public | Visibility::Default => {
+            let parents = pub_items.entry(&item.id).or_default();
+            if let Some(parent_id) = parent_id {
+                parents.push(parent_id);
+            }
+
+            let next_parent_id = Some(&item.id);
+            match &item.inner {
+                rustdoc_types_17::ItemEnum::Module(m) => {
+                    for inner in m.items.iter().filter_map(|id| crate_.index.get(id)) {
+                        collect_public_items(crate_, pub_items, inner, next_parent_id);
+                    }
+                }
+                rustdoc_types_17::ItemEnum::Import(imp) => {
+                    // TODO: handle glob imports (`pub use foo::bar::*`) here.
+                    if let Some(item) = imp.id.as_ref().and_then(|id| crate_.index.get(id)) {
+                        collect_public_items(crate_, pub_items, item, next_parent_id);
+                    }
+                }
+                rustdoc_types_17::ItemEnum::Struct(struct_) => {
+                    let field_ids_iter: Box<dyn Iterator<Item = &Id>> = match &struct_.kind {
+                        rustdoc_types_17::StructKind::Unit => Box::new(std::iter::empty()),
+                        rustdoc_types_17::StructKind::Tuple(field_ids) => {
+                            Box::new(field_ids.iter().filter_map(|x| x.as_ref()))
+                        }
+                        rustdoc_types_17::StructKind::Plain { fields, .. } => Box::new(fields.iter()),
+                    };
+
+                    for inner in field_ids_iter
+                        .chain(struct_.impls.iter())
+                        .filter_map(|id| crate_.index.get(id))
+                    {
+                        collect_public_items(crate_, pub_items, inner, next_parent_id);
+                    }
+                }
+                rustdoc_types_17::ItemEnum::Enum(enum_) => {
+                    for inner in enum_
+                        .variants
+                        .iter()
+                        .chain(enum_.impls.iter())
+                        .filter_map(|id| crate_.index.get(id))
+                    {
+                        collect_public_items(crate_, pub_items, inner, next_parent_id);
+                    }
+                }
+                rustdoc_types_17::ItemEnum::Trait(trait_) => {
+                    for inner in trait_.items.iter().filter_map(|id| crate_.index.get(id)) {
+                        collect_public_items(crate_, pub_items, inner, next_parent_id);
+                    }
+                }
+                rustdoc_types_17::ItemEnum::Impl(impl_) => {
+                    for inner in impl_.items.iter().filter_map(|id| crate_.index.get(id)) {
+                        collect_public_items(crate_, pub_items, inner, next_parent_id);
+                    }
+                }
+                _ => {
+                    // No-op, no further items within to consider.
+                }
+            }
+        }
+        Visibility::Crate | Visibility::Restricted { .. } => {}
+    }
+}

--- a/src/rustdoc_v21/mod.rs
+++ b/src/rustdoc_v21/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod adapter;
+pub(crate) mod indexed_crate;


### PR DESCRIPTION
Prototype for supporting multiple rustdoc format versions in the same version of cargo-semver-checks (related to #126). Intended for discussion, and not planned to merge as-is.

It supports rustdoc JSON format v18 and v21, and will happily deserialize either file format. However, the baseline and current JSON files must have the same version -- no mixing and matching is allowed. This constraint is not a problem for the GitHub Action or the common ways of using cargo-semver-checks from the terminal.

I'm strongly considering splitting out the version-specific `rustdoc_vX` directories (containing the Trustfall adapters for each format version) into their own crate, which for ease of use could have major version X compatible with rustdoc JSON format version X. Another crate could perhaps include the "choose whichever version makes sense" functionality and provide a `Box<dyn Adapter>` for Trustfall querying. This would probably be useful outside of cargo-semver-checks since this is not the only use case for querying rustdoc JSON.