### PR TITLE
chore: release v0.12.0; temporarily disable semver-check on publish.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,10 +160,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Check semver
-        uses: obi1kenobi/cargo-semver-checks-action@v1
-        with:
-          # cargo-semver-checks currently doesn't have a --lib target,
-          # so we explicitly ask for the binary target to be checked instead.
-          # For library crates, you almost always want the default `--lib` value here.
-          crate-target: --bin cargo-semver-checks
+      # - name: Check semver
+      #   uses: obi1kenobi/cargo-semver-checks-action@v1
+      #   with:
+      #     # cargo-semver-checks currently doesn't have a --lib target,
+      #     # so we explicitly ask for the binary target to be checked instead.
+      #     # For library crates, you almost always want the default `--lib` value here.
+      #     crate-target: --bin cargo-semver-checks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-semver-checks"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-semver-checks"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 authors = ["Predrag Gruevski <obi1kenobi82@gmail.com>"]
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
The semver-checking action needs this latest version of
cargo-semver-checks to work with multiple compilers. It currently won't
work -- I'm fixing that next.
