### PR TITLE
Consistently use 'v' before version numbers.

### DIFF
--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -266,7 +266,7 @@ path = 'lib.rs'
 
         config.shell_status(
             "Parsing",
-            format_args!("{} {} (baseline)", name, base_version),
+            format_args!("{} v{} (baseline)", name, base_version),
         )?;
         let rustdoc_path = rustdoc.dump(
             manifest_path.as_path(),


### PR DESCRIPTION
I noticed a small inconsistency in this command log: https://github.com/libp2p/rust-libp2p/actions/runs/3254423615/jobs/5342659716

```
    Updating index
     Parsing libp2p-core v0.37.0 (current)
     Parsing libp2p-core 0.37.0 (baseline)
```

The "current" line has a `v` prefix before the version number, whereas the "baseline" one does not. This PR adds the `v` to the "baseline" line as well, to make them consistent.