### PR TITLE
Rename skipped checks to unnecessary checks for clarity.

### DIFF
--- a/src/check_release.rs
+++ b/src/check_release.rs
@@ -129,7 +129,7 @@ pub(super) fn run_check_release(
             config.shell_status(
                 "Starting",
                 format_args!(
-                    "{} checks, {} skipped (allowed by version change)",
+                    "{} checks, {} unnecessary",
                     queries_to_run.len(),
                     skipped_queries
                 ),
@@ -226,7 +226,7 @@ pub(super) fn run_check_release(
             .shell_print(
                 "Completed",
                 format_args!(
-                    "[{:>8.3}s] {} checks; {} passed, {} failed, {} skipped",
+                    "[{:>8.3}s] {} checks; {} passed, {} failed, {} unnecessary",
                     total_duration.as_secs_f32(),
                     queries_to_run.len(),
                     queries_to_run.len() - queries_with_errors.len(),
@@ -355,7 +355,7 @@ pub(super) fn run_check_release(
             .shell_print(
                 "Completed",
                 format_args!(
-                    "[{:>8.3}s] {} checks; {} passed, {} skipped",
+                    "[{:>8.3}s] {} checks; {} passed, {} unnecessary",
                     total_duration.as_secs_f32(),
                     queries_to_run.len(),
                     queries_to_run.len(),

--- a/src/check_release.rs
+++ b/src/check_release.rs
@@ -129,7 +129,7 @@ pub(super) fn run_check_release(
             config.shell_status(
                 "Starting",
                 format_args!(
-                    "{} checks, {} skipped",
+                    "{} checks, {} skipped (allowed by version change)",
                     queries_to_run.len(),
                     skipped_queries
                 ),


### PR DESCRIPTION
Users reported some confusion around why checks were being skipped: https://github.com/libp2p/rust-libp2p/pull/2647#issuecomment-1256852275

This PR updates the "skipped" message terminology to use "unnecessary" instead. Here's an example before/after.

Before:
```
Completed [   0.551s] 18 checks; 17 passed, 1 failed, 0 skipped
```

After:
```
Completed [   0.551s] 18 checks; 17 passed, 1 failed, 0 unnecessary
```
