### PR TITLE
Require `--bugreport` output in bug report issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,9 +22,11 @@ body:
       required: true
   - type: textarea
     attributes:
-      label: "Additional Context"
-      description: "Add any other context about the problem here."
+      label: "Generated System Information"
+      description: "Run `cargo semver-checks --bugreport` and copy-paste the output here."
+    validations:
+      required: true
   - type: textarea
     attributes:
-      label: "Debug Output"
-      description: "Run `cargo semver-checks --bugreport`"
+      label: "Additional Context"
+      description: "Add any other context about the problem here."


### PR DESCRIPTION
The current field is positioned at the end, after the "additional context" field, and ends up getting skipped.

Let's try moving it up one slot and making it required.