### PR TITLE
Report the regular cargo version, not nightly.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,11 +26,7 @@ fn main() -> anyhow::Result<()> {
             .info(SoftwareVersion::default())
             .info(OperatingSystem::default())
             .info(CommandLine::default())
-            .info(CommandOutput::new(
-                "cargo nightly version",
-                "cargo",
-                &["+nightly", "-V"],
-            ))
+            .info(CommandOutput::new("cargo version", "cargo", &["-V"]))
             .info(CompileTimeInformation::default())
             .print::<Markdown>();
         std::process::exit(0);


### PR DESCRIPTION
cargo-semver-checks no longer requires nightly, so the relevant version
in the `--bugreport` output is the current cargo version, not nightly.
