### PR TITLE
Add running cargo-semver-checks on rust-libp2p

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
         with:
           persist-credentials: false
           repository: 'libp2p/rust-libp2p'
-          ref: 'bcff814b92c76706a2df46098e3c8a61f29ef9fc'
+          ref: '3371d7ce'
           path: 'crate'
 
       - name: Install rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
         with:
           persist-credentials: false
           repository: 'libp2p/rust-libp2p'
-          ref: '3371d7ce'
+          ref: '3371d7ceab242440216ae9ab99829631fa418f3b'
           path: 'crate'
 
       - name: Install rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,9 @@ jobs:
           profile: minimal
           override: true
 
+      - name: Install protobuf-compiler
+        run: sudo apt install protobuf-compiler
+
       - name: Run semver-checks
         run: cargo run semver-checks check-release --manifest-path="crate/core/Cargo.toml"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,34 @@ jobs:
 
       - name: test
         run: cargo test
+  
+  run-on-crate:
+    name: Run cargo-semver-checks on rust-libp2p 0.49.0
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cargo-semver-check
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Checkout rust-libp2p
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          repository: 'libp2p/rust-libp2p'
+          ref: 'bcff814b92c76706a2df46098e3c8a61f29ef9fc'
+          path: 'crate'
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+          profile: minimal
+          override: true
+
+      - name: Run semver-checks
+        run: cargo run semver-checks check-release --manifest-path="crate/core/Cargo.toml"
 
   publish:
     name: Publish to crates.io


### PR DESCRIPTION
PR to solve https://github.com/obi1kenobi/cargo-semver-check/issues/178

As mentioned in https://github.com/obi1kenobi/cargo-semver-check/issues/178, there should be some support for running checks on multiple crates in CI. I think that that could be adjusted in a follow up PR by using a matrix, but that would be easier to do when a specific crate is given, especially since there can be some dependencies needed (like protobuf-compiler in rust-libp2p)